### PR TITLE
Adds missing deallocations and fixes an indexing issue

### DIFF
--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -333,7 +333,7 @@ module ocn_adc_mixing_fused
                                     ws(i1,1,iCell)**2 / (sp2 * 0.99_RKIND**2 + 1.0E-15_RKIND))
             tau_sfc = length(1,iCell) / sqrt(0.5_RKIND*(u2(i1,1,iCell) + v2(i1,1,iCell)))
 
-            if(w2(k,1,iCell) + tau_sfc * w2tend6(1,iCell) < min_wps_sfc_val) then
+            if(w2(i1,1,iCell) + tau_sfc * w2tend6(1,iCell) < min_wps_sfc_val) then
                wp2_splat_sfc_correction = -w2(i1,1,iCell) + min_wp2_sfc_val
                w2(i1,1,iCell) = min_wp2_sfc_val
             else

--- a/src/core_ocean/shared/mpas_ocn_turbulence.F
+++ b/src/core_ocean/shared/mpas_ocn_turbulence.F
@@ -377,7 +377,7 @@ module ocn_turbulence
       w2tend3 = w2tend3Tmp
       w2tend4 = w2tend4Tmp
       w2tend5 = w2tend5Tmp
-      w3tend6 = w2tend6Tmp
+      w2tend6 = w2tend6Tmp
       w3tend1 = w3tend1Tmp
       w3tend2 = w3tend2Tmp
       w3tend3 = w3tend3Tmp
@@ -1470,7 +1470,10 @@ module ocn_turbulence
                  vs,          &
                  ts,          &
                  s2,          &
-                 eps)
+                 eps,         &
+                 Mc,          &
+                 KspsDtend,   &
+                 KspsUtend)
 
    end subroutine ocn_turbulenceDestroy
 

--- a/src/core_ocean/shared/mpas_ocn_vmix_adc.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_adc.F
@@ -520,27 +520,33 @@ contains
 
      integer, intent(out) :: ierr
 
-     deallocate(KspsU, KspsD, ze, zm,          &
-                eps, length, lenspsD, lenspsU, &
-                KhU, KhD, KmU, KmD,            &
-                wt_spsU, wt_spsD, ws_spsU, ws_spsD, &
-                uw2, vw2, u2w, v2w, w2t,  &
-                w2s, wts, uvw, uwt, vwt,  &
+     deallocate(KspsU, KspsD, ze, zm, eps, epsSPS,   &
+                length, lenspsD, lenspsU,            &
+                KhU, KhD, KmU, KmD, lenup, lendn,    &
+                wt_spsU, wt_spsD, ws_spsU, ws_spsD,  &
+                uw2, vw2, u2w, v2w, w2t,             &
+                w2s, wts, uvw, uwt, vwt, uws, vws,   &
                 ws2, wt2, areaFraction, Entrainment, &
                 Detrainment, tumd, sumd, wumd,       &
                 w2tend1, w2tend2, w2tend3, w2tend4,  &
-                w2tend5, wttend1, wttend2, wttend3,  &
+                w2tend5, w2tend6, w3tend1, w3tend2,  &
+                w3tend3, w3tend4, w3tend5, w3tend6,  &
+                wttend1, wttend2, wttend3, wttend6,  &
                 wttend4, wttend5, wstend1, wstend2,  &
-                wstend3, wstend4, wstend5, uwtend1,  &
-                uwtend2, uwtend3, uwtend4, uwtend5,  &
-                vwtend1, vwtend2, vwtend3, vwtend4,  &
-                vwtend5, u2tend1, u2tend2, u2tend3,  &
-                u2tend4, u2tend5, v2tend1, v2tend2,  &
-                v2tend3, v2tend4, v2tend5, u2cliptend, &
-                v2cliptend, w2cliptend, u2, v2,      &
-                w2, wt, ws, uw, vw,        &
-                w3, uv, t2, s2, ut,        &
-                vt, us, vs, ts)
+                wstend3, wstend4, wstend5, wstend6,  &
+                uwtend1, uwtend2, uwtend3, uwtend4,  &
+                uwtend5, vwtend1, vwtend2, vwtend3,  &
+                vwtend4, vwtend5, u2tend1, u2tend2,  &
+                u2tend3, u2tend4, u2tend5, u2tend6,  &
+                v2tend1, v2tend2, v2tend3, v2tend4,  &
+                v2tend5, v2tend6, u2cliptend,        &
+                v2cliptend, w2cliptend, u2tend,      &
+                v2tend, w2tend, wttend, wstend,      &
+                uwtend, vwtend, w3tend, uvtend,      &
+                epstend, uttend, vttend, ustend,     &
+                vstend, tstend, u2, v2, w2, wt, ws,  &
+                uw, vw, w3, uv, t2, s2, ut, vt, us,  &
+                vs, ts, Mc, KspsUtend, KspsDtend)
 
    end subroutine ocn_vmix_adc_finalize
 


### PR DESCRIPTION
Adds missing deallocations of variables in adc mixing model and fixes a minor indexing issue within the new splat parameterization code. Neither appears to fix the current issue in #18, but were found in the process of trying to debug that issue and I thought they might as well be fixed now that we know about them. Testing revealed this to be a BFB match change, at least for a simple convective cooling case with the splat parameterization turned on. 

