### PR TITLE
Adds ability to truncate tendencies and/or change units in ADC calc from MKgS to CGS

### DIFF
--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -11,6 +11,14 @@
 	      description="flag to use buoyancy length scale from previous closure, temporary"
 	      possible_values=".true. or .false."
 	      />
+  <nml_option name="config_adc_truncate_tend" type="logical" default_value=".false." units="unitless"
+	      description="flag to truncate tendency terms"
+	      possible_values=".true. or .false."
+	      />
+  <nml_option name="config_adc_decimals_to_keep" type="real" default_value="1.0E12" units="unitless"
+	      description="number of decimal places to keep, inverse is position of decimal rounding"
+	      possible_values="large positive reals"
+	      />
   <nml_option name="config_adc_tau_o" type="real" default_value="1800" units="s^{-1}"
 	      description="characterstic eddy turnover timescale"
 	      possible_values="positive real numbers"

--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -15,7 +15,7 @@
 	      description="flag to truncate tendency terms"
 	      possible_values=".true. or .false."
 	      />
-  <nml_option name="config_adc_decimals_to_keep" type="real" default_value="1.0E12" units="unitless"
+  <nml_option name="config_adc_decimals_to_keep" type="real" default_value="12" units="unitless"
 	      description="number of decimal places to keep, inverse is position of decimal rounding"
 	      possible_values="large positive reals"
 	      />

--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -19,6 +19,10 @@
 	      description="number of decimal places to keep, inverse is position of decimal rounding"
 	      possible_values="large positive reals"
 	      />
+  <nml_option name="config_adc_convert_to_CGS" type="logical" default_value=".false." units="unitless"
+	      description="flag to convert mass flux closure calculation to centimeter-grams-seconds units"
+	      possible_values=".true. or .false."
+	      />
   <nml_option name="config_adc_tau_o" type="real" default_value="1800" units="s^{-1}"
 	      description="characterstic eddy turnover timescale"
 	      possible_values="positive real numbers"

--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -1,632 +1,632 @@
 <nml_record name="adcMixingModel" mode="forward">
-		<nml_option name="config_adc_enable" type="logical" default_value=".false." units="unitless"
-			description="If true, the new mass flux RANS closure is called for mixing"
-			possible_values=".true. or .false."
-		/>
-		<nml_option name="config_adc_timestep" type="real" default_value="1" units="unitless"
-			description="timestep for the turbulence updates and subcycling (now in sec, probably should unify with MPAS later)"
-			possible_values="small positive reals (less than MPAS timestep)"
-    />
-    <nml_option name="config_adc_use_old_length_scale" type="logical" default_value=".false." units="unitless"
-      description="flag to use buoyancy length scale from previous closure, temporary"
-      possible_values=".true. or .false."
-    />
-    <nml_option name="config_adc_tau_o" type="real" default_value="1800" units="s^{-1}"
-      description="characterstic eddy turnover timescale"
-      possible_values="positive real numbers"
-      />
-    <nml_option name="config_adc_length_multiple" type="real" default_value="2.0" units="unitless"
-      description="value to multiply length scale by"
-      possible_values="small positive real numbers"
-      />
-    <nml_option name="config_adc_epsilon" type="real" default_value="1e-8" units="m^2/s^2"
-      description="small value below which KE, u2, w2, v2 is not allowed to go below"
-      possible_values="very small numbers 1e-8 to zero"
-      />
-    <nml_option name="config_adc_use_single_column" type="logical" default_value=".true." units="unitless"
-      description="if true, ADC code runs on 1 copy and is copied to the others to speed testing"
-      possible_values=".true. or .false."
-      />
-		<nml_option name="config_adc_sigmat" type="real" default_value="0.72" units="unitless"
-			description="sigma_t constant for RANS equations"
-			possible_values="can modify some, but highly recommend not altering"
-      />
-    <nml_option name="config_adc_Ko" type="real" default_value="4.574296" units="unitless"
-      description="Ko in RANS equations"
-      possible_values="can modify to cerain extent, but highly recommend not altering"
-      />
-		<nml_option name="config_adc_c_b_tracer" type="real" default_value="0.33" units="unitless"
-			description="Buoyancy partitioning for pressure correlation term in tracer flux budgets"
-			possible_values="0.33 and values close to it"
-		/>
-		<nml_option name="config_adc_c_b" type="real" default_value="0.5" units="unitless"
-			description="c_b buoyancy contribution to pressure correlation in w2 equation"
-			possible_values="values near 0.5"
-      />
-		<nml_option name="config_adc_alpha_0" type="real" default_value="0.8" units="unitless"
-			description="alpha_0 first (TKE) rapid pressure coefficient for second-moment budgets"
-			possible_values="values near 0.8"
-	    />
-		<nml_option name="config_adc_alpha_1" type="real" default_value="0.984" units="unitless"
-			description="alpha_1 second (strain) rapid pressure coefficient"
-			possible_values="values near 1.0"
-		  />
-		<nml_option name="config_adc_alpha_2" type="real" default_value="0.568" units="unitless"
-			description="alpha_2 third (vorticity) rapid pressure coefficient"
-			possible_values="values near 0.6"
-		  />
-		<nml_option name="config_adc_alpha_tracer1" type="real" default_value="0.6" units="unitless"
-			description="alpha_scalar1 first rapid pressure coefficient in tracer flux budgets (Mironov 2001)"
-			possible_values="suggested values: 0.6 (Canuto 2001) or equal to alpha_scalar2, >0, <1 (Harcourt 2013)"
-			/>
-		<nml_option name="config_adc_alpha_tracer2" type="real" default_value="1.0" units="unitless"
-			description="alpha_scalar2 rapid pressure coefficient in tracer flux budgets (Mironov 2001)"
-			possible_values="suggested values: 1.0 (Canuto 2001) or equal to alpha_scalar2, >0, <1 (Harcourt 2013)"
-			/>
-    <nml_option name="config_adc_c11" type="real" default_value="0.1" units="unitless"
-      description="c_11 is the buoyancy contribution in the pressure correlation in w3 eqn"
-      possible_values="values near 0.1"
-    />
-		<nml_option name="config_adc_Cmom" type="real" default_value="0.0" units="unitless"
-			description="third order down gradient coefficient, from lappen and randall 2001b"
-			possible_values="values near 0.5"
-      />
-    <nml_option name="config_adc_Ctherm" type="real" default_value="0.0" units="unitless"
-      description="thir order down gradient for buoyancy moments, from lappen and randall 2001b"
-      possible_values="values near 4.85"
-      />
-    <nml_option name="config_adc_Cmom_w3" type="real" default_value="4.0" units="unitless"
-      description="dissipation of w3 from LR01b"
-      possible_values="values near 6"
-      />
-    <nml_option name="config_adc_c_slow" type="real" default_value="2.0" units="unitless"
-      description="c_slow coefficient for slow pressure term in velocity-based tendency equations"
-      possible_values="values near 2"
-      />
-    <nml_option name="config_adc_slow_w_factor" type="real" default_value="0.875" units="unitless"
-      description="c_slow_w_factor factor for adjusting slow pressure term in ww budget"
-      possible_values="values near 1"
-    />
-		<nml_option name="config_adc_c_slow_tracer" type="real" default_value="2.0" units="unitless"
-      description="c_slow_tracer coefficient for slow pressure term in tracer-based tendency equations"
-      possible_values="values near 2"
-      />
-    <nml_option name="config_adc_dissipation_constant" type="real" default_value = "5.0" units="unitless"
-      description="factor multiplying the dissipation parameterization"
-      possible_values="positive values less than 16"
-    />
-    <nml_option name="config_adc_CwwE" type="real" default_value="1.0" units="unitless"
-      description="coefficient for entrainment in parameterization from LR01b"
-      possible_values="values near 1.0, also CwwD/CwwE must be near 1.5"
-      />
-    <nml_option name="config_adc_CwwD" type="real" default_value="1.5" units="unitless"
-      description="coefficient for detrainment in parameteriztaion from LR01b"
-      possible_values="values near 1.0, also CwwD/CwwE must be near 1.5"
-      />
-    <nml_option name="config_adc_kappaFL" type="real" default_value="0" units="m^2/s"
-      description="background diffusion coefficient for fluxes, second moments"
-      possible_values="small positive real numbers"
-      />
-    <nml_option name="config_adc_kappaVAR" type="real" default_value="0" units="m^2/s"
-      description="background diffusion coefficient for variances, i.e. T'^2"
-      possible_values="small positive real numbers"
-      />
-    <nml_option name="config_adc_kappaW3" type="real" default_value="0" units="m^2/s"
-      description="background diffusion coefficient for w3"
-      possible_values="small positive real numbers"
-	  />
-	<nml_option name="config_adc_bc_wstar" type="real" default_value="0.3" units="unitless"
-	  description="scaling factor in front of the surface boundary condition on wstar"
-	  possible_values="small positive real numbers"
-	/>
-	<nml_option name="config_adc_frictionVelocityMin" type="real" default_value="1.0e-5" units="m^2/s^2"
-	  description="minimum allowable surface friction velocity squared"
-	  possible_values="very small positive real numbers"
-	/>
-	<nml_option name="config_adc_bc_const" type="real" default_value="1.8" units="unitless"
-	  description="constant multiplying surface boundary condition, taken from CLUBB"
-	  possible_values="small positive real numbers"
-	/>
-	<nml_option name="config_adc_bc_const_wp2" type="real" default_value="1.8" units="unitless"
-	  description="identical to previous parameter but for wp2 to allow disabling"
-	  possible_values="small positive real numbers or zero"
-	/>
-	<nml_option name="config_adc_use_splat_parameterization" type="logical" default_value=".true." units="unitless"
-	  description="flag to use the splat parameterization"
-	  possible_values=".true. or .false."
-	/>
-	<nml_option name="config_adc_splat_tend_max" type="real" default_value="1.0e-5" units="m^2/s^3"
-	  description="maximum tendency of the splat term"
-	  possible_values="very small positive values"
-	/>
-	<nml_option name="config_adc_splat_wp2_val" type="real" default_value="2.0" units="unitless"
-	  description="factor multiplying the splat term in wp2 and wp3"
-	  possible_values="small positive real numbers"
-	/>
-	<nml_option name="config_adc_up2_vp2_factor" type="real" default_value="4.0" units="unitless"
-	  description="factor multiplying the boundary condition on up2 and vp2"
-	  possible_values="small positive real numbers"
-	/>
-	</nml_record>
-	<packages>
-		<package name="adcMixingPKG" description="This package includes variables required for the assumed distribution closure model."/>
-	</packages>
-	<var_struct name="adcDiagnosticArrays" time_levs="1" packages="adcMixingPKG">
-		<var name="ze" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
-			 description="depth coordinate at cell top referenced to zero at SSH"
-		/>
-		<var name="zm" type="real" dimensions="nVertLevels nCells Time" units="m"
-			 description="depth coordinate at cell mid referenced to zero at SSH"
+  <nml_option name="config_adc_enable" type="logical" default_value=".false." units="unitless"
+	      description="If true, the new mass flux RANS closure is called for mixing"
+	      possible_values=".true. or .false."
+	      />
+  <nml_option name="config_adc_timestep" type="real" default_value="1" units="unitless"
+	      description="timestep for the turbulence updates and subcycling (now in sec, probably should unify with MPAS later)"
+	      possible_values="small positive reals (less than MPAS timestep)"
+	      />
+  <nml_option name="config_adc_use_old_length_scale" type="logical" default_value=".false." units="unitless"
+	      description="flag to use buoyancy length scale from previous closure, temporary"
+	      possible_values=".true. or .false."
+	      />
+  <nml_option name="config_adc_tau_o" type="real" default_value="1800" units="s^{-1}"
+	      description="characterstic eddy turnover timescale"
+	      possible_values="positive real numbers"
+	      />
+  <nml_option name="config_adc_length_multiple" type="real" default_value="2.0" units="unitless"
+	      description="value to multiply length scale by"
+	      possible_values="small positive real numbers"
+	      />
+  <nml_option name="config_adc_epsilon" type="real" default_value="1e-8" units="m^2/s^2"
+	      description="small value below which KE, u2, w2, v2 is not allowed to go below"
+	      possible_values="very small numbers 1e-8 to zero"
+	      />
+  <nml_option name="config_adc_use_single_column" type="logical" default_value=".true." units="unitless"
+	      description="if true, ADC code runs on 1 copy and is copied to the others to speed testing"
+	      possible_values=".true. or .false."
+	      />
+  <nml_option name="config_adc_sigmat" type="real" default_value="0.72" units="unitless"
+	      description="sigma_t constant for RANS equations"
+	      possible_values="can modify some, but highly recommend not altering"
+	      />
+  <nml_option name="config_adc_Ko" type="real" default_value="4.574296" units="unitless"
+	      description="Ko in RANS equations"
+	      possible_values="can modify to cerain extent, but highly recommend not altering"
+	      />
+  <nml_option name="config_adc_c_b_tracer" type="real" default_value="0.33" units="unitless"
+	      description="Buoyancy partitioning for pressure correlation term in tracer flux budgets"
+	      possible_values="0.33 and values close to it"
+	      />
+  <nml_option name="config_adc_c_b" type="real" default_value="0.5" units="unitless"
+	      description="c_b buoyancy contribution to pressure correlation in w2 equation"
+	      possible_values="values near 0.5"
+	      />
+  <nml_option name="config_adc_alpha_0" type="real" default_value="0.8" units="unitless"
+	      description="alpha_0 first (TKE) rapid pressure coefficient for second-moment budgets"
+	      possible_values="values near 0.8"
+	      />
+  <nml_option name="config_adc_alpha_1" type="real" default_value="0.984" units="unitless"
+	      description="alpha_1 second (strain) rapid pressure coefficient"
+	      possible_values="values near 1.0"
+	      />
+  <nml_option name="config_adc_alpha_2" type="real" default_value="0.568" units="unitless"
+	      description="alpha_2 third (vorticity) rapid pressure coefficient"
+	      possible_values="values near 0.6"
+	      />
+  <nml_option name="config_adc_alpha_tracer1" type="real" default_value="0.6" units="unitless"
+	      description="alpha_scalar1 first rapid pressure coefficient in tracer flux budgets (Mironov 2001)"
+	      possible_values="suggested values: 0.6 (Canuto 2001) or equal to alpha_scalar2, >0, <1 (Harcourt 2013)"
+  />
+  <nml_option name="config_adc_alpha_tracer2" type="real" default_value="1.0" units="unitless"
+	      description="alpha_scalar2 rapid pressure coefficient in tracer flux budgets (Mironov 2001)"
+	      possible_values="suggested values: 1.0 (Canuto 2001) or equal to alpha_scalar2, >0, <1 (Harcourt 2013)"
+  />
+  <nml_option name="config_adc_c11" type="real" default_value="0.1" units="unitless"
+	      description="c_11 is the buoyancy contribution in the pressure correlation in w3 eqn"
+	      possible_values="values near 0.1"
+	      />
+  <nml_option name="config_adc_Cmom" type="real" default_value="0.0" units="unitless"
+	      description="third order down gradient coefficient, from lappen and randall 2001b"
+	      possible_values="values near 0.5"
+	      />
+  <nml_option name="config_adc_Ctherm" type="real" default_value="0.0" units="unitless"
+	      description="thir order down gradient for buoyancy moments, from lappen and randall 2001b"
+	      possible_values="values near 4.85"
+	      />
+  <nml_option name="config_adc_Cmom_w3" type="real" default_value="4.0" units="unitless"
+	      description="dissipation of w3 from LR01b"
+	      possible_values="values near 6"
+	      />
+  <nml_option name="config_adc_c_slow" type="real" default_value="2.0" units="unitless"
+	      description="c_slow coefficient for slow pressure term in velocity-based tendency equations"
+	      possible_values="values near 2"
+	      />
+  <nml_option name="config_adc_slow_w_factor" type="real" default_value="0.875" units="unitless"
+	      description="c_slow_w_factor factor for adjusting slow pressure term in ww budget"
+	      possible_values="values near 1"
+	      />
+  <nml_option name="config_adc_c_slow_tracer" type="real" default_value="2.0" units="unitless"
+	      description="c_slow_tracer coefficient for slow pressure term in tracer-based tendency equations"
+	      possible_values="values near 2"
+	      />
+  <nml_option name="config_adc_dissipation_constant" type="real" default_value = "5.0" units="unitless"
+	      description="factor multiplying the dissipation parameterization"
+	      possible_values="positive values less than 16"
+	      />
+  <nml_option name="config_adc_CwwE" type="real" default_value="1.0" units="unitless"
+	      description="coefficient for entrainment in parameterization from LR01b"
+	      possible_values="values near 1.0, also CwwD/CwwE must be near 1.5"
+	      />
+  <nml_option name="config_adc_CwwD" type="real" default_value="1.5" units="unitless"
+	      description="coefficient for detrainment in parameteriztaion from LR01b"
+	      possible_values="values near 1.0, also CwwD/CwwE must be near 1.5"
+	      />
+  <nml_option name="config_adc_kappaFL" type="real" default_value="0" units="m^2/s"
+	      description="background diffusion coefficient for fluxes, second moments"
+	      possible_values="small positive real numbers"
+	      />
+  <nml_option name="config_adc_kappaVAR" type="real" default_value="0" units="m^2/s"
+	      description="background diffusion coefficient for variances, i.e. T'^2"
+	      possible_values="small positive real numbers"
+	      />
+  <nml_option name="config_adc_kappaW3" type="real" default_value="0" units="m^2/s"
+	      description="background diffusion coefficient for w3"
+	      possible_values="small positive real numbers"
+	      />
+  <nml_option name="config_adc_bc_wstar" type="real" default_value="0.3" units="unitless"
+	      description="scaling factor in front of the surface boundary condition on wstar"
+	      possible_values="small positive real numbers"
+	      />
+  <nml_option name="config_adc_frictionVelocityMin" type="real" default_value="1.0e-5" units="m^2/s^2"
+	      description="minimum allowable surface friction velocity squared"
+	      possible_values="very small positive real numbers"
+	      />
+  <nml_option name="config_adc_bc_const" type="real" default_value="1.8" units="unitless"
+	      description="constant multiplying surface boundary condition, taken from CLUBB"
+	      possible_values="small positive real numbers"
+	      />
+  <nml_option name="config_adc_bc_const_wp2" type="real" default_value="1.8" units="unitless"
+	      description="identical to previous parameter but for wp2 to allow disabling"
+	      possible_values="small positive real numbers or zero"
+	      />
+  <nml_option name="config_adc_use_splat_parameterization" type="logical" default_value=".true." units="unitless"
+	      description="flag to use the splat parameterization"
+	      possible_values=".true. or .false."
+	      />
+  <nml_option name="config_adc_splat_tend_max" type="real" default_value="1.0e-5" units="m^2/s^3"
+	      description="maximum tendency of the splat term"
+	      possible_values="very small positive values"
+	      />
+  <nml_option name="config_adc_splat_wp2_val" type="real" default_value="2.0" units="unitless"
+	      description="factor multiplying the splat term in wp2 and wp3"
+	      possible_values="small positive real numbers"
+	      />
+  <nml_option name="config_adc_up2_vp2_factor" type="real" default_value="4.0" units="unitless"
+	      description="factor multiplying the boundary condition on up2 and vp2"
+	      possible_values="small positive real numbers"
+	      />
+</nml_record>
+<packages>
+  <package name="adcMixingPKG" description="This package includes variables required for the assumed distribution closure model."/>
+</packages>
+<var_struct name="adcDiagnosticArrays" time_levs="1" packages="adcMixingPKG">
+  <var name="ze" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
+       description="depth coordinate at cell top referenced to zero at SSH"
        />
-    <var name="epsSPS" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^{-3}"
-      description="dissipation of plume scale TKE"
-      />
-    <var name="length" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
-      description="master length scale for turbulent dissipation"
-      />
-    <var name="lendn" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
-      description="length scale for downward moving plumes"
-      />
-    <var name="lenup" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
-      description="length scale for upward moving plumes"
-      />
-    <var name="lenspsD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
-      description="length scale associated with downward moving plumes"
-      />
-    <var name="lenspsU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
-      description="length scale associated with upward moving plumes"
-      />
-    <var name="KhU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s"
-      description="diffusivity for subplume scale temp/salinity fluxes (upward moving)"
-      />
-    <var name="KhD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s"
-      description="diffusivity for subplume temp/salinity scale fluxes (downward moving)"
-      />
-    <var name="KmU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s"
-      description="viscosity for subplume momentum fluxes (upward moving)"
-      />
-    <var name="KmD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s"
-      description="viscosity for subplume momentum fluxes (downward moving)"
-      />
-    <var name="wt_spsU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
-      description="subplume upward moving temperature flux"
-      />
-    <var name="wt_spsD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
-      description="subplume downward moving temperature flux"
-      />
-     <var name="ws_spsU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
-      description="subplume upward moving salinity flux"
-      />
-    <var name="ws_spsD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
-      description="subplume downward moving salinity flux"
-      />
-    <var name="uw2" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
-      description="turbulent transport of E-W momentum flux"
-      />
-    <var name="vw2" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
-      description="turbulent transport of NS momentum flux"
-      />
-    <var name="u2w" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
-      description="turbulent transport EW momentum variance"
-      />
-    <var name="v2w" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
-      description="turbulent transport NS momentum variance"
-      />
-    <var name="w2t" type="real" dimensions="nVertLevels nCells Time" units="m^2 C/s^2"
-      description="turbulent transport of vertical temperature flux"
-      />
-    <var name="w2s" type="real" dimensions="nVertLevels nCells Time" units="m^2 PSU/s^2"
-      description="turbulent transport of vertical salinity flux"
-      />
-    <var name="wts" type="real" dimensions="nVertLevels nCells Time" units="m C PSU/s"
-      description="turbulent transport of temperature salinity covariance"
-      />
-    <var name="uvw" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
-      description="turbulent transport of u-v covariance"
-    />
-    <var name="uwt" type="real" dimensions="nVertLevels nCells Time" units="m^2 C /s^2"
-      description="turbulent transport of EW temperature flux"
-      />
-    <var name="vwt" type="real" dimensions="nVertLevels nCells Time" units="m^2 C /s^2"
-      description="turbulent transport of NS temperature flux"
-      />
-    <var name="uws" type="real" dimensions="nVertLevels nCells Time" units="m^2 PSU/s^2"
-      description="turbulent transport of EW salinity flux"
-      />
-    <var name="vws" type="real" dimensions="nVertLevels nCells Time" units="m^2 PSU/s^2"
-      description="turbulent transport of NS salinity flux"
-      />
-    <var name="ws2" type="real" dimensions="nVertLevels nCells Time" units="m PSU^2/s"
-      description="turbulent transport of salinity variance"
-      />
-    <var name="wt2" type="real" dimensions="nVertLevels nCells Time" units="m C^2/s"
-      description="turbulent transport of temperature variance"
-      />
-    <var name="areaFraction" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
-      description="area fraction of upward moving plumes"
-      />
-    <var name="Entrainment" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
-      description="entrainment diagnosed from LR01b parameterization"
-      />
-    <var name="Detrainment" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
-      description="detrainment diagnosed from LR01b parameterization"
-      />
-    <var name="tumd" type="real" dimensions="nVertLevelsP1 nCells Time" units="C"
-      description="upward moving temperature - downward moving temperature"
-      />
-    <var name="sumd" type="real" dimensions="nVertLevelsP1 nCells Time" units="PSU"
-      description="upward moving salinity - downward moving salinity"
-      />
-    <var name="wumd" type="real" dimensions="nVertLevelsP1 nCells Time" units="m/s"
-      description="upward moving vertical velocity - downward moving (negative) vertical velocity"
-      />
-    <var name="Mc" type="real" dimensions="nVertLevelsP1 nCells Time" units="m/s"
-      description="convective mass flux"
-      />
-
-	</var_struct>
-	<var_struct name="adcTendArrays" time_levs="1" packages="adcMixingPKG">
-    <var name="w2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="entrainment production term -- similar to dissipation"
-		/>
-    <var name="w2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-      description="third order moment term (d / dz w^3)"
-		/>
-    <var name="w2tend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="return to isotropy term"
-		/>
-    <var name="w2tend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="buoyancy production term"
-		/>
-    <var name="w2tend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="shear production term"
+  <var name="zm" type="real" dimensions="nVertLevels nCells Time" units="m"
+       description="depth coordinate at cell mid referenced to zero at SSH"
        />
-	<var name="w2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="conversion of w2 due to splat effects"
-	/>
-    <var name="w3tend1" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-			 description="entrainment production term -- similar to dissipation"
-		/>
-    <var name="w3tend2" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-      description="fourth order moment term (d / dz w^4)"
-		/>
-    <var name="w3tend3" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-      description="w2 d/dz w2"
-		/>
-    <var name="w3tend4" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-			 description="subplume terms + return to isotropy, latter dominates"
-		/>
-    <var name="w3tend5" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-			 description="third order moment of buoyancy, turb transport of buoyancy fluxes"
-			 />
-	<var name="w3tend6" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-			 description="destruction due to splat effects"
-	/>
-    <var name="wttend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="divergence of turbulent transport of flux"
-		/>
-    <var name="wttend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-      description="gradient production w^2 dTdz"
-		/>
-    <var name="wttend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="buoyancy term"
-		/>
-    <var name="wttend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="return to isotropy"
-		/>
-    <var name="wttend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="shear production term"
+  <var name="epsSPS" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^{-3}"
+       description="dissipation of plume scale TKE"
        />
-    <var name="wttend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="subplume scale production term"
+  <var name="length" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
+       description="master length scale for turbulent dissipation"
        />
-    <var name="wstend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="divergence of turbulent transport of flux"
-		/>
-    <var name="wstend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-      description="gradient production w^2 dTdz"
-		/>
-    <var name="wstend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="buoyancy term"
-		/>
-    <var name="wstend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="return to isotropy"
-		/>
-    <var name="wstend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="shear production term"
+  <var name="lendn" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
+       description="length scale for downward moving plumes"
        />
-    <var name="wstend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="subplume scale production term"
+  <var name="lenup" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
+       description="length scale for upward moving plumes"
        />
-    <var name="uwtend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="divergence of turbulent transport of flux"
-		/>
-    <var name="uwtend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-      description="gradient production "
-		/>
-    <var name="uwtend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="uv covariance"
-		/>
-    <var name="uwtend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="horizontal buoyancy flux term"
-		/>
-    <var name="uwtend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="return to isotropy"
+  <var name="lenspsD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
+       description="length scale associated with downward moving plumes"
        />
-    <var name="vwtend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="divergence of turbulent transport of flux"
-		/>
-    <var name="vwtend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-      description="gradient production "
-		/>
-    <var name="vwtend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="uv covariance"
-		/>
-    <var name="vwtend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="horizontal buoyancy flux term"
-		/>
-    <var name="vwtend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="return to isotropy"
+  <var name="lenspsU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m"
+       description="length scale associated with upward moving plumes"
        />
-    <var name="u2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="divergence of turbulent transport of flux"
-		/>
-    <var name="u2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-      description="gradient production proportional to dUdz"
-		/>
-    <var name="u2tend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="gradient production proportional to dVdz"
-		/>
-    <var name="u2tend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="buoyancy production"
-		/>
-    <var name="u2tend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="return to isotropy"
-    />
-	<var name="u2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="production due to splatting of w'2"
-	/>
-    <var name="v2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="divergence of turbulent transport of flux"
-		/>
-    <var name="v2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-      description="gradient production proportional to dUdz"
-		/>
-    <var name="v2tend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="gradient production proportional to dVdz"
-		/>
-    <var name="v2tend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="buoyancy production"
-		/>
-    <var name="v2tend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="return to isotropy"
-	/>
-	<var name="v2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-			 description="production due to splatting of w'2"
-	/>
-    <var name="u2cliptend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="KhU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s"
+       description="diffusivity for subplume scale temp/salinity fluxes (upward moving)"
+       />
+  <var name="KhD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s"
+       description="diffusivity for subplume temp/salinity scale fluxes (downward moving)"
+       />
+  <var name="KmU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s"
+       description="viscosity for subplume momentum fluxes (upward moving)"
+       />
+  <var name="KmD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s"
+       description="viscosity for subplume momentum fluxes (downward moving)"
+       />
+  <var name="wt_spsU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
+       description="subplume upward moving temperature flux"
+       />
+  <var name="wt_spsD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
+       description="subplume downward moving temperature flux"
+       />
+  <var name="ws_spsU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
+       description="subplume upward moving salinity flux"
+       />
+  <var name="ws_spsD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
+       description="subplume downward moving salinity flux"
+       />
+  <var name="uw2" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
+       description="turbulent transport of E-W momentum flux"
+       />
+  <var name="vw2" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
+       description="turbulent transport of NS momentum flux"
+       />
+  <var name="u2w" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
+       description="turbulent transport EW momentum variance"
+       />
+  <var name="v2w" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
+       description="turbulent transport NS momentum variance"
+       />
+  <var name="w2t" type="real" dimensions="nVertLevels nCells Time" units="m^2 C/s^2"
+       description="turbulent transport of vertical temperature flux"
+       />
+  <var name="w2s" type="real" dimensions="nVertLevels nCells Time" units="m^2 PSU/s^2"
+       description="turbulent transport of vertical salinity flux"
+       />
+  <var name="wts" type="real" dimensions="nVertLevels nCells Time" units="m C PSU/s"
+       description="turbulent transport of temperature salinity covariance"
+       />
+  <var name="uvw" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
+       description="turbulent transport of u-v covariance"
+       />
+  <var name="uwt" type="real" dimensions="nVertLevels nCells Time" units="m^2 C /s^2"
+       description="turbulent transport of EW temperature flux"
+       />
+  <var name="vwt" type="real" dimensions="nVertLevels nCells Time" units="m^2 C /s^2"
+       description="turbulent transport of NS temperature flux"
+       />
+  <var name="uws" type="real" dimensions="nVertLevels nCells Time" units="m^2 PSU/s^2"
+       description="turbulent transport of EW salinity flux"
+       />
+  <var name="vws" type="real" dimensions="nVertLevels nCells Time" units="m^2 PSU/s^2"
+       description="turbulent transport of NS salinity flux"
+       />
+  <var name="ws2" type="real" dimensions="nVertLevels nCells Time" units="m PSU^2/s"
+       description="turbulent transport of salinity variance"
+       />
+  <var name="wt2" type="real" dimensions="nVertLevels nCells Time" units="m C^2/s"
+       description="turbulent transport of temperature variance"
+       />
+  <var name="areaFraction" type="real" dimensions="nVertLevelsP1 nCells Time" units="unitless"
+       description="area fraction of upward moving plumes"
+       />
+  <var name="Entrainment" type="real" dimensions="nVertLevelsP1 nCells Time" units="1/s^2"
+       description="entrainment diagnosed from LR01b parameterization"
+       />
+  <var name="Detrainment" type="real" dimensions="nVertLevelsP1 nCells Time" units="1/s^2"
+       description="detrainment diagnosed from LR01b parameterization"
+       />
+  <var name="tumd" type="real" dimensions="nVertLevelsP1 nCells Time" units="C"
+       description="upward moving temperature - downward moving temperature"
+       />
+  <var name="sumd" type="real" dimensions="nVertLevelsP1 nCells Time" units="PSU"
+       description="upward moving salinity - downward moving salinity"
+       />
+  <var name="wumd" type="real" dimensions="nVertLevelsP1 nCells Time" units="m/s"
+       description="upward moving vertical velocity - downward moving (negative) vertical velocity"
+       />
+  <var name="Mc" type="real" dimensions="nVertLevelsP1 nCells Time" units="m/s"
+       description="convective mass flux"
+       />
+  
+</var_struct>
+<var_struct name="adcTendArrays" time_levs="1" packages="adcMixingPKG">
+  <var name="w2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="entrainment production term -- similar to dissipation"
+       />
+  <var name="w2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="third order moment term (d / dz w^3)"
+       />
+  <var name="w2tend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="return to isotropy term"
+       />
+  <var name="w2tend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="buoyancy production term"
+       />
+  <var name="w2tend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="shear production term"
+       />
+  <var name="w2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="conversion of w2 due to splat effects"
+       />
+  <var name="w3tend1" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+       description="entrainment production term -- similar to dissipation"
+       />
+  <var name="w3tend2" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+       description="fourth order moment term (d / dz w^4)"
+       />
+  <var name="w3tend3" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+       description="w2 d/dz w2"
+       />
+  <var name="w3tend4" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+       description="subplume terms + return to isotropy, latter dominates"
+       />
+  <var name="w3tend5" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+       description="third order moment of buoyancy, turb transport of buoyancy fluxes"
+       />
+  <var name="w3tend6" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+       description="destruction due to splat effects"
+       />
+  <var name="wttend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="divergence of turbulent transport of flux"
+       />
+  <var name="wttend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="gradient production w^2 dTdz"
+       />
+  <var name="wttend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="buoyancy term"
+       />
+  <var name="wttend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="return to isotropy"
+       />
+  <var name="wttend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="shear production term"
+       />
+  <var name="wttend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="subplume scale production term"
+       />
+  <var name="wstend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="divergence of turbulent transport of flux"
+       />
+  <var name="wstend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="gradient production w^2 dTdz"
+       />
+  <var name="wstend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="buoyancy term"
+       />
+  <var name="wstend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="return to isotropy"
+       />
+  <var name="wstend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="shear production term"
+       />
+  <var name="wstend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="subplume scale production term"
+       />
+  <var name="uwtend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="divergence of turbulent transport of flux"
+       />
+  <var name="uwtend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="gradient production "
+       />
+  <var name="uwtend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="uv covariance"
+       />
+  <var name="uwtend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="horizontal buoyancy flux term"
+       />
+  <var name="uwtend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="return to isotropy"
+       />
+  <var name="vwtend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="divergence of turbulent transport of flux"
+       />
+  <var name="vwtend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="gradient production "
+       />
+  <var name="vwtend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="uv covariance"
+       />
+  <var name="vwtend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="horizontal buoyancy flux term"
+       />
+  <var name="vwtend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="return to isotropy"
+       />
+  <var name="u2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="divergence of turbulent transport of flux"
+       />
+  <var name="u2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="gradient production proportional to dUdz"
+       />
+  <var name="u2tend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="gradient production proportional to dVdz"
+       />
+  <var name="u2tend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="buoyancy production"
+       />
+  <var name="u2tend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="return to isotropy"
+       />
+  <var name="u2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="production due to splatting of w'2"
+       />
+  <var name="v2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="divergence of turbulent transport of flux"
+       />
+  <var name="v2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="gradient production proportional to dUdz"
+       />
+  <var name="v2tend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="gradient production proportional to dVdz"
+       />
+  <var name="v2tend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="buoyancy production"
+       />
+  <var name="v2tend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="return to isotropy"
+       />
+  <var name="v2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="production due to splatting of w'2"
+       />
+  <var name="u2cliptend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="if less than zero, it is reset to zero, this stores when that is active"
-    />
-    <var name="v2cliptend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="if less than zero, it is reset to zero, this stores when that is active"
-    />
-    <var name="w2cliptend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="if less than zero, it is reset to zero, this stores when that is active"
-    />
-	</var_struct>
-  <var_struct name="adcPrognosticArrays" time_levs="3" packages="adcMixingPKG">
-    <var name="KspsU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^{-2}"
-			 description="sub plume scale TKE for upward moving plumes"
        />
-    <var name="KspsUtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="v2cliptend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="if less than zero, it is reset to zero, this stores when that is active"
+       />
+  <var name="w2cliptend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="if less than zero, it is reset to zero, this stores when that is active"
+       />
+</var_struct>
+<var_struct name="adcPrognosticArrays" time_levs="3" packages="adcMixingPKG">
+  <var name="KspsU" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^{-2}"
+       description="sub plume scale TKE for upward moving plumes"
+       />
+  <var name="KspsUtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="tendency of upward moving plumes"
        />
-    <var name="KspsD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^{-2}"
-			 description="sub plume scale TKE for downward moving plumes"
-       />
-    <var name="KspsDtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="KspsD" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^{-2}"
        description="sub plume scale TKE for downward moving plumes"
        />
-    <var name="eps" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="KspsDtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="sub plume scale TKE for downward moving plumes"
+       />
+  <var name="eps" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="prognostic dissipation rate"
        />
-    <var name="epstend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^4"
+  <var name="epstend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^4"
        description="tendency of dissipation"
        />
-    <var name="u2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
-			 description="EW velocity variance"
+  <var name="u2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
+       description="EW velocity variance"
        />
-    <var name="u2tend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="u2tend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="EW velocity variance tendency"
        />
-    <var name="v2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
-			 description="NS velocity variance"
+  <var name="v2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
+       description="NS velocity variance"
        />
-    <var name="v2tend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="v2tend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="NS velocity variance tendency"
        />
-    <var name="w2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
-      description="vertical velocity variance"
-      />
-    <var name="w2tend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-      description="vertical velocity variance tendency"
-      />
-    <var name="wt" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
-			 description="vertical turbulent temperature flux"
+  <var name="w2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
+       description="vertical velocity variance"
        />
-    <var name="wttend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
+  <var name="w2tend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="vertical velocity variance tendency"
+       />
+  <var name="wt" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
+       description="vertical turbulent temperature flux"
+       />
+  <var name="wttend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
        description="vertical turbulent temperature flux tendency"
        />
-    <var name="ws" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s"
-			 description="vertical turbulent salinity flux"
+  <var name="ws" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s"
+       description="vertical turbulent salinity flux"
        />
-    <var name="wstend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
+  <var name="wstend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
        description="vertical turbulent salinity flux tendency"
        />
-    <var name="uw" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
+  <var name="uw" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
        description="vertical flux of zonal momentum"
        />
-    <var name="uwtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="uwtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="vertical EW momentum flux tendency"
        />
-    <var name="vw" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
+  <var name="vw" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
        description="vertical flux of NS momentum"
        />
-    <var name="vwtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="vwtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="vertical flux of NS momentum tendency"
        />
-    <var name="w3" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
+  <var name="w3" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^3"
        description="vertical flux of vertical velocity variance -- skewness"
        />
-    <var name="w3tend" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^4"
+  <var name="w3tend" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^4"
        description="vertical flux of w3 tendency"
        />
-    <var name="uv" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
+  <var name="uv" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^2"
        description="NS/EW momentum covariance"
        />
-    <var name="uvtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="uvtend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="uv tendency"
        />
-    <var name="t2" type="real" dimensions="nVertLevelsP1 nCells Time" units="C^2"
+  <var name="t2" type="real" dimensions="nVertLevelsP1 nCells Time" units="C^2"
        description="temperature variance"
        />
-    <var name="s2" type="real" dimensions="nVertLevelsP1 nCells Time" units="PSU^2"
+  <var name="s2" type="real" dimensions="nVertLevelsP1 nCells Time" units="PSU^2"
        description="salinity variance"
        />
-    <var name="ut" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
+  <var name="ut" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
        description="horizontal temperature flux -- zonal direction"
        />
-    <var name="uttend" type="real" dimensions="nVertLevelsP1 nCells Time" units="mC/s^2"
+  <var name="uttend" type="real" dimensions="nVertLevelsP1 nCells Time" units="mC/s^2"
        description="tendency of ut"
        />
-    <var name="vt" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
+  <var name="vt" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s"
        description="horizontal temperature flux -- meridional direction"
        />
-    <var name="vttend" type="real" dimensions="nVertLevelsP1 nCells Time" units="mC/s^2"
+  <var name="vttend" type="real" dimensions="nVertLevelsP1 nCells Time" units="mC/s^2"
        description="tendency of vt"
        />
-    <var name="us" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s"
+  <var name="us" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s"
        description="horizontal salinity flux -- zonal direction"
        />
-    <var name="ustend" type="real" dimensions="nVertLevelsP1 nCells Time" units="mPSU/s^2"
+  <var name="ustend" type="real" dimensions="nVertLevelsP1 nCells Time" units="mPSU/s^2"
        description="tendency of us"
        />
-    <var name="vs" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s"
+  <var name="vs" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s"
        description="horizontal salinity flux -- meridional direction"
        />
-    <var name="vstend" type="real" dimensions="nVertLevelsP1 nCells Time" units="mPSU/s^2"
+  <var name="vstend" type="real" dimensions="nVertLevelsP1 nCells Time" units="mPSU/s^2"
        description="tendency of vs"
        />
-    <var name="ts" type="real" dimensions="nVertLevelsP1 nCells Time" units="C PSU"
+  <var name="ts" type="real" dimensions="nVertLevelsP1 nCells Time" units="C PSU"
        description="temperature salinity covariance"
        />
-    <var name="tstend" type="real" dimensions="nVertLevelsP1 nCells Time" units="C PSU/s"
+  <var name="tstend" type="real" dimensions="nVertLevelsP1 nCells Time" units="C PSU/s"
        description="tendency of ts"
        />
-	</var_struct>
+</var_struct>
 
-  	<streams>
-		<stream name="adcTurbulenceOutput" type="output"
-				mode="forward;analysis"
-				filename_template="output/adcTurbulenceArrays.$Y-$M-$D.nc"
-				filename_interval="01-00-00_00:00:00"
-				output_interval="00-00-00_01:00:00"
-				reference_time="0001-01-01_00:00:00"
-				packages="mixedLayerDepthsAMPKG"
-				clobber_mode="truncate"
-				runtime_format="single_file">
-
-			<stream name="mesh"/>
-			<var name="xtime"/>
-			<var name="KspsU"/>
-			<var name="KspsD"/>
-			<var name="eps"/>
-      <var name="length"/>
-      <var name="lendn"/>
-      <var name="lenup"/>
-      <var name="lenspsD"/>
-      <var name="lenspsU"/>
-      <var name="KhU"/>
-      <var name="KhD"/>
-      <var name="wt_spsU"/>
-      <var name="wt_spsD"/>
-      <var name="ws_spsU"/>
-      <var name="ws_spsD"/>
-      <var name="uw2"/>
-      <var name="vw2"/>
-      <var name="u2w"/>
-      <var name="v2w"/>
-      <var name="w2t"/>
-      <var name="w2s"/>
-      <var name="wt2"/>
-      <var name="ws2"/>
-      <var name="wts"/>
-      <var name="uvw"/>
-      <var name="uwt"/>
-      <var name="vwt"/>
-      <var name="uws"/>
-      <var name="vws"/>
-      <var name="sigma"/>
-      <var name="Entrainment"/>
-      <var name="Detrainment"/>
-      <var name="tumd"/>
-      <var name="sumd"/>
-      <var name="wumd"/>
-      <var name="w2tend1"/>
-      <var name="w2tend2"/>
-      <var name="w2tend3"/>
-      <var name="w2tend4"/>
-      <var name="w2tend5"/>
-      <var name="u2tend1"/>
-      <var name="u2tend2"/>
-      <var name="u2tend3"/>
-      <var name="u2tend4"/>
-      <var name="u2tend5"/>
-      <var name="v2tend1"/>
-      <var name="v2tend2"/>
-      <var name="v2tend3"/>
-      <var name="v2tend4"/>
-      <var name="v2tend5"/>
-      <var name="uwtend1"/>
-      <var name="uwtend2"/>
-      <var name="uwtend3"/>
-      <var name="uwtend4"/>
-      <var name="uwtend5"/>
-      <var name="vwtend1"/>
-      <var name="vwtend2"/>
-      <var name="vwtend3"/>
-      <var name="vwtend4"/>
-      <var name="vwtend5"/>
-      <var name="w3tend1"/>
-      <var name="w3tend2"/>
-      <var name="w3tend3"/>
-      <var name="w3tend4"/>
-      <var name="w3tend5"/>
-      <var name="wttend1"/>
-      <var name="wttend2"/>
-      <var name="wttend3"/>
-      <var name="wttend4"/>
-      <var name="wttend5"/>
-      <var name="wstend1"/>
-      <var name="wstend2"/>
-      <var name="wstend3"/>
-      <var name="wstend4"/>
-      <var name="wstend5"/>
-      <var name="u2"/>
-      <var name="v2"/>
-      <var name="w2"/>
-      <var name="s2"/>
-      <var name="t2"/>
-      <var name="uw"/>
-      <var name="vw"/>
-      <var name="wt"/>
-      <var name="ws"/>
-      <var name="w3"/>
-      <var name="uv"/>
-      <var name="ut"/>
-      <var name="vt"/>
-      <var name="us"/>
-      <var name="vs"/>
-      <var name="ts"/>
-		</stream>
-	</streams>
+<streams>
+  <stream name="adcTurbulenceOutput" type="output"
+	  mode="forward;analysis"
+	  filename_template="output/adcTurbulenceArrays.$Y-$M-$D.nc"
+	  filename_interval="01-00-00_00:00:00"
+	  output_interval="00-00-00_01:00:00"
+	  reference_time="0001-01-01_00:00:00"
+	  packages="mixedLayerDepthsAMPKG"
+	  clobber_mode="truncate"
+	  runtime_format="single_file">
+    
+    <stream name="mesh"/>
+    <var name="xtime"/>
+    <var name="KspsU"/>
+    <var name="KspsD"/>
+    <var name="eps"/>
+    <var name="length"/>
+    <var name="lendn"/>
+    <var name="lenup"/>
+    <var name="lenspsD"/>
+    <var name="lenspsU"/>
+    <var name="KhU"/>
+    <var name="KhD"/>
+    <var name="wt_spsU"/>
+    <var name="wt_spsD"/>
+    <var name="ws_spsU"/>
+    <var name="ws_spsD"/>
+    <var name="uw2"/>
+    <var name="vw2"/>
+    <var name="u2w"/>
+    <var name="v2w"/>
+    <var name="w2t"/>
+    <var name="w2s"/>
+    <var name="wt2"/>
+    <var name="ws2"/>
+    <var name="wts"/>
+    <var name="uvw"/>
+    <var name="uwt"/>
+    <var name="vwt"/>
+    <var name="uws"/>
+    <var name="vws"/>
+    <var name="sigma"/>
+    <var name="Entrainment"/>
+    <var name="Detrainment"/>
+    <var name="tumd"/>
+    <var name="sumd"/>
+    <var name="wumd"/>
+    <var name="w2tend1"/>
+    <var name="w2tend2"/>
+    <var name="w2tend3"/>
+    <var name="w2tend4"/>
+    <var name="w2tend5"/>
+    <var name="u2tend1"/>
+    <var name="u2tend2"/>
+    <var name="u2tend3"/>
+    <var name="u2tend4"/>
+    <var name="u2tend5"/>
+    <var name="v2tend1"/>
+    <var name="v2tend2"/>
+    <var name="v2tend3"/>
+    <var name="v2tend4"/>
+    <var name="v2tend5"/>
+    <var name="uwtend1"/>
+    <var name="uwtend2"/>
+    <var name="uwtend3"/>
+    <var name="uwtend4"/>
+    <var name="uwtend5"/>
+    <var name="vwtend1"/>
+    <var name="vwtend2"/>
+    <var name="vwtend3"/>
+    <var name="vwtend4"/>
+    <var name="vwtend5"/>
+    <var name="w3tend1"/>
+    <var name="w3tend2"/>
+    <var name="w3tend3"/>
+    <var name="w3tend4"/>
+    <var name="w3tend5"/>
+    <var name="wttend1"/>
+    <var name="wttend2"/>
+    <var name="wttend3"/>
+    <var name="wttend4"/>
+    <var name="wttend5"/>
+    <var name="wstend1"/>
+    <var name="wstend2"/>
+    <var name="wstend3"/>
+    <var name="wstend4"/>
+    <var name="wstend5"/>
+    <var name="u2"/>
+    <var name="v2"/>
+    <var name="w2"/>
+    <var name="s2"/>
+    <var name="t2"/>
+    <var name="uw"/>
+    <var name="vw"/>
+    <var name="wt"/>
+    <var name="ws"/>
+    <var name="w3"/>
+    <var name="uv"/>
+    <var name="ut"/>
+    <var name="vt"/>
+    <var name="us"/>
+    <var name="vs"/>
+    <var name="ts"/>
+  </stream>
+</streams>

--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -19,10 +19,6 @@
 	      description="number of decimal places to keep, inverse is position of decimal rounding"
 	      possible_values="large positive reals"
 	      />
-  <nml_option name="config_adc_convert_to_CGS" type="logical" default_value=".false." units="unitless"
-	      description="flag to convert mass flux closure calculation to centimeter-grams-seconds units"
-	      possible_values=".true. or .false."
-	      />
   <nml_option name="config_adc_tau_o" type="real" default_value="1800" units="s^{-1}"
 	      description="characterstic eddy turnover timescale"
 	      possible_values="positive real numbers"

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -183,10 +183,9 @@ module ocn_adc_mixing_fused
       real(kind=RKIND),dimension(nVertLevels,nCells) :: areaFractionMid, tumdMid, McMid, wumdMid, sumdMid
 
       real(kind=RKIND) :: SwU, SwD, tau_sfc, d_sqrt_wp2_dz, tp2, sp2, min_wp2_sfc_val, wp2_splat_sfc_correction
-      real(kind=RKIND) :: min_wps_sfc_val, adcRound
+      real(kind=RKIND) :: min_wps_sfc_val
 
       min_wps_sfc_val = 1.0E-10_RKIND
-      adcRound = 10.0_RKIND**config_adc_decimals_to_keep
       dt_small = config_adc_timestep
       niter = dt / dt_small
 

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -197,7 +197,7 @@ module ocn_adc_mixing_fused
       do iIter=1,niter
 !     on further examination build_diagnostics array can live outside the iter loop
          do iCell=1,nCells
-            Q = grav*(alphaT(1,iCell)*wtsfc(iCell) - betaS(1,iCell)*wssfc(iCell))* &
+            Q = grav*(alphaT(1,iCell)*wtsfc(iCell) + betaS(1,iCell)*wssfc(iCell))* &
               boundaryLayerDepth(iCell)
               if(Q > 0) then
                  wstar = abs(Q)**(1.0_RKIND/3.0_RKIND)
@@ -222,7 +222,7 @@ module ocn_adc_mixing_fused
                  uw(k,1,iCell) = -uwsfc(iCell)
                  vw(k,1,iCell) = -vwsfc(iCell)
                  wt(k,1,iCell) = wtsfc(iCell)
-                 ws(k,1,iCell) = wssfc(iCell)
+                 ws(k,1,iCell) = -wssfc(iCell)
                  KE = 0.5_RKIND*(u2(i1,1,iCell) + v2(i1,1,iCell))
                  eps(k,1,iCell) = KE**1.5_RKIND/(0.5_RKIND*(ze(1,iCell) - ze(2,iCell) + 1.0E-10_RKIND))
               enddo

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -13,8 +13,19 @@ module ocn_adc_mixing_fused
 
   integer :: i1_f, i2_f, i3_f, i1, i2
   real(kind=RKIND) :: Cw1, Cw2, Cw3
+  real(kind=RKIND) :: MtoCM
 
   contains
+
+  subroutine CGS_convert
+
+    if (config_adc_convert_to_CGS) then
+       MtoCM = 1000.0_RKIND
+    else
+       MtoCM = 1.0_RKIND
+    endif
+
+  end subroutine CGS_convert
 
   subroutine get_array_pointers
 
@@ -62,6 +73,7 @@ module ocn_adc_mixing_fused
       real (kind=RKIND) :: sumv, sumv0
       real (kind=RKIND), parameter :: refT = 15.0_RKIND, refS = 35.0_RKIND, minlen = 0.55_RKIND
 
+      call CGS_convert
 
 !     NOTE: will need to convert to some form of displaced density in the mpas framework soon
 !     possibly go back to a more traditional length scale formulation
@@ -85,11 +97,11 @@ module ocn_adc_mixing_fused
          do k = 1,nVertLevels+1
             KEsps(k) = areaFraction(k,iCell) * KspsD(i1,k,iCell) + &
               (1.0_RKIND - areaFraction(k,iCell)) * KspsU(i1,k,iCell)
-            tke(k) = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell)) ! + KEsps(k)
+            tke(k) = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell))
          enddo
 
          do k = 1,nVertLevels+1
-            Bedge(k) = gravity * (alphaEdge(k) * (tedge(k) - refT) - &
+            Bedge(k) = gravity * MtoCM * (alphaEdge(k) * (tedge(k) - refT) - &
               betaEdge(k)  * (sedge(k) - refS))
 
             sigav = areaFraction(k,iCell)
@@ -101,9 +113,10 @@ module ocn_adc_mixing_fused
             Sup = sedge(k) + sigav*sumdav
             Sdn = sedge(k) - (1.0_RKIND - sigav)*sumdav
             
-            Bupedge(k) = gravity * (alphaEdge(k) * (Tup - refT) - betaEdge(k) * (Sup - refS))
-            Bdnedge(k) = gravity * (alphaEdge(k) * (Tdn - refT) - betaEdge(k) * (Sdn - refS))
+            Bupedge(k) = gravity * MtoCM * (alphaEdge(k) * (Tup - refT) - betaEdge(k) * (Sup - refS))
+            Bdnedge(k) = gravity * MtoCM * (alphaEdge(k) * (Tdn - refT) - betaEdge(k) * (Sdn - refS))
          enddo
+
          do k = 2,nVertLevels
 !           updraft length scale
             sumv  = 0.0_RKIND
@@ -113,8 +126,7 @@ module ocn_adc_mixing_fused
             do while(sumv0 <= tke(k) .and. ij > 1)
                sumv = sumv0 + (BEdge(ij) - BupEdge(k)) * (ze(ij-1,iCell)-ze(ij,iCell))
                if (sumv > tke(k)) THEN
-                  lenup(k,iCell) = max(minlen, &
-                    lenup(k,iCell) + &
+                  lenup(k,iCell) = max(minlen*MtoCM, lenup(k,iCell) + &
                     abs(ze(ij-1,iCell)-ze(ij,iCell))*(tke(k)-sumv0)/(sumv-sumv0))
                     exit
                else
@@ -132,8 +144,7 @@ module ocn_adc_mixing_fused
             do while(sumv0 <= tke(k) .and. ij < nVertLevels+1)
                sumv = sumv0 + (BdnEdge(k) - BEdge(ij)) * (ze(ij-1,iCell)-ze(ij,iCell))
                if (sumv > tke(k)) THEN
-                  lendn(k,iCell) = max(minlen, &
-                    lendn(k,iCell) + &
+                  lendn(k,iCell) = max(minlen*MtoCM, lendn(k,iCell) + &
                     abs(ze(ij-1,iCell)-ze(ij,iCell))*(tke(k)-sumv0)/(sumv-sumv0))
                     exit
                else
@@ -148,8 +159,8 @@ module ocn_adc_mixing_fused
          enddo
       enddo
 
-      length(1,iCell) = 0.55_RKIND
-      length(nVertLevels+1,iCell) = 0.55_RKIND
+      length(1,iCell) = 0.55_RKIND*MtoCM
+      length(nVertLevels+1,iCell) = 0.55_RKIND*MtoCM
 
   end subroutine dissipation_lengths2
 
@@ -191,6 +202,7 @@ module ocn_adc_mixing_fused
       dt_small = config_adc_timestep
       niter = dt / dt_small
 
+      call CGS_convert
       call get_array_pointers
       call get_weights
 
@@ -199,7 +211,7 @@ module ocn_adc_mixing_fused
       do iIter=1,niter
 !     on further examination build_diagnostics array can live outside the iter loop
          do iCell=1,nCells
-            Q = grav*(alphaT(1,iCell)*wtsfc(iCell) - betaS(1,iCell)*wssfc(iCell))* &
+            Q = grav*MtoCM*(alphaT(1,iCell)*wtsfc(iCell) - betaS(1,iCell)*wssfc(iCell))* &
               boundaryLayerDepth(iCell)
               if(Q > 0) then
                  wstar = abs(Q)**(1.0_RKIND/3.0_RKIND)
@@ -211,16 +223,16 @@ module ocn_adc_mixing_fused
               wumd(1,iCell) = 0.0_RKIND
               areaFraction(1,iCell) = 0.5_RKIND
               Mc(1,iCell) = 0.0_RKIND
-              w2t(1,iCell) = -0.3_RKIND*wstar * wtsfc(iCell)
-              w2s(1,iCell) = 0.3_RKIND*wstar * wssfc(iCell)
+              w2t(1,iCell) = 0.0_RKIND !-0.3_RKIND*wstar * wtsfc(iCell)
+              w2s(1,iCell) = 0.0_RKIND !0.3_RKIND*wstar * wssfc(iCell)
 
               sfcFrictionVelocitySquared = uwsfc(iCell) + vwsfc(iCell)
               frictionVelocity = sqrt(sfcFrictionVelocitySquared + config_adc_bc_wstar * wstar * wstar)
-              frictionVelocity = max( config_adc_frictionVelocityMin, frictionVelocity )
+!              frictionVelocity = max( config_adc_frictionVelocityMin, frictionVelocity )
               do k=1,3
                  u2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
                  v2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
-                 w2(k,1,iCell) = config_adc_bc_const_wp2*frictionVelocity**2.0_RKIND
+                 w2(k,1,iCell) = 0.0_RKIND !config_adc_bc_const_wp2*frictionVelocity**2.0_RKIND
                  uw(k,1,iCell) = -uwsfc(iCell)
                  vw(k,1,iCell) = -vwsfc(iCell)
                  wt(k,1,iCell) = wtsfc(iCell)
@@ -337,7 +349,7 @@ module ocn_adc_mixing_fused
                  tumd(k,iCell) = wt(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
                  sumd(k,iCell) = ws(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
 
-                 if(w2(i1,k,iCell) <= epsilon + 1.0e-9_RKIND) then
+                 if(w2(i1,k,iCell) <= epsilon*MtoCM*MtoCM + 1.0e-9_RKIND) then
                     tumd(k,iCell) = 0.0_RKIND
                     sumd(k,iCell) = 0.0_RKIND
                  endif
@@ -426,9 +438,9 @@ module ocn_adc_mixing_fused
                  w3tend1(k,iCell) = -wumdav**3.0_RKIND*(Eav*(3.0_RKIND*sigav - 2.0_RKIND) &
                    + Dav*(3.0_RKIND*sigav - 1.0_RKIND))
 
-                 SwU = -(1.0_RKIND-2.0_RKIND*areaFraction(k,iCell))
+                 SwU = -(1.0_RKIND-2.0_RKIND*areaFraction(k,iCell)) &
                    /(areaFraction(k,iCell)*(1.0_RKIND-areaFraction(k,iCell)))**0.5_RKIND
-                 SwD = -(1.0_RKIND-2.0_RKIND*areaFraction(k+1,iCell))
+                 SwD = -(1.0_RKIND-2.0_RKIND*areaFraction(k+1,iCell)) &
                    /(areaFraction(k+1,iCell)*(1.0_RKIND-areaFraction(k+1,iCell)))**0.5_RKIND
                  w3tend2(k,iCell) = -((3.0_RKIND + SwU**2.0_RKIND)*(w2(i1,k,iCell)**2.0_RKIND) - &
                    (3.0_RKIND + SwD**2.0_RKIND)*(w2(i1,k+1,iCell)**2.0_RKIND) ) / dz
@@ -436,14 +448,14 @@ module ocn_adc_mixing_fused
 
                  w3tend4(k,iCell) = -3.0_RKIND*(1.0_RKIND - 2.0_RKIND*sigav)*Mcav*wumdav*Swumd(k,iCell) - &
                    tauw3(k,iCell)*w3(i1,k,iCell)
-                 w3tend5(k,iCell) = 3.0_RKIND*(1.0_RKIND - c11)*grav*(alphaT(k,iCell)*w2t(k,iCell) - &
+                 w3tend5(k,iCell) = 3.0_RKIND*(1.0_RKIND - c11)*grav*MtoCM*(alphaT(k,iCell)*w2t(k,iCell) - &
                    betaS(k,iCell)*w2s(k,iCell))
 
                  w3tend(i3_f,k,iCell) = w3tend1(k,iCell) + w3tend2(k,iCell) + w3tend3(k,iCell) + &
-                 w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell)
+                   w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell)
 
-                 if(k>1 .and. k < nVertLevels .and. kappa_w3 > 0.0_RKIND) then
-                    w3tend(i3_f,k,iCell) = w3tend(i3_f,k,iCell) + kappa_w3*(w3(i1,k-1,iCell) &
+                 if(k>1 .and. k < nVertLevels .and. kappa_w3*MtoCM*MtoCM > 0.0_RKIND) then
+                    w3tend(i3_f,k,iCell) = w3tend(i3_f,k,iCell) + kappa_w3*MtoCM*MtoCM*(w3(i1,k-1,iCell) &
                       - w3(i1,k+1,iCell)) / (zm(k-1,iCell) - zm(k+1,iCell))**2.0_RKIND
                  endif
 
@@ -478,7 +490,7 @@ module ocn_adc_mixing_fused
               do k=2,nVertLevels
                  dzmid = (zm(k-1,iCell) - zm(k,iCell))
                  dz = ze(k-1,iCell) - ze(k,iCell)
-                 B = grav*(alphaT(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND - &
+                 B = grav*MtoCM*(alphaT(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND - &
                    areaFraction(k,iCell))*wumd(k,iCell)*tumd(k,iCell) -      &
                    betaS(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND -          &
                    areaFraction(k,iCell))*wumd(k,iCell)*sumd(k,iCell))
@@ -502,7 +514,7 @@ module ocn_adc_mixing_fused
                    (1.0_RKIND - 2.0_RKIND*areaFractionMid(k,iCell))*wumdMid(k,iCell)**2.0_RKIND) / dzmid
                  w2tend3(k,iCell) = tauvVel(k,iCell)*(u2(i1,k,iCell) + v2(i1,k,iCell))/3.0_RKIND
                  w2tend4(k,iCell) = (2.0_RKIND - 4.0_RKIND/3.0_RKIND*C_b)*Mc(k,iCell)* &
-                   (grav*alphaT(k,iCell)*tumd(k,iCell) - grav*betaS(k,iCell)*sumd(k,iCell))
+                   (grav*MtoCM*alphaT(k,iCell)*tumd(k,iCell) - grav*MtoCM*betaS(k,iCell)*sumd(k,iCell))
                  w2tend5(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 -            &
                    alpha_2)*(uw(i1,k,iCell)*Uz + vw(i1,k,iCell)*Vz) +         &
                    Mc(k,iCell)*(Swumd(k-1,iCell) + Swumd(k,iCell))
@@ -517,18 +529,14 @@ module ocn_adc_mixing_fused
 
                  wttend1(k,iCell) = -1.0_RKIND*(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
                    wumd(k,iCell)*tumd(k,iCell)
-                 wttend2(k,iCell) = ((1.0_RKIND - 2.0_RKIND*areaFraction(k-1,iCell))* &
-                   wumd(k-1,iCell)*tumd(k-1,iCell)*Mc(k-1,iCell) - (1.0_RKIND - 2.0_RKIND* &
-                   areaFraction(k+1,iCell))*wumd(k+1,iCell)*tumd(k+1,iCell)*Mc(k+1,iCell)) &
-                   / (ze(k-1,iCell) - ze(k+1,iCell)) - 0.0_RKIND*Mc(k,iCell)*wumd(k,iCell)*Tz
                  wttend2(k,iCell) = -(w2t(k-1,iCell) - w2t(k,iCell)) / (zm(k-1,iCell) - zm(k,iCell)) - &
                    Mc(k,iCell)*wumd(k,iCell)*Tz*0.0_RKIND
                  wttend3(k,iCell) = (1.0_RKIND - C_b_tracer)*areaFraction(k,iCell)*  &
-                   (1.0_RKIND - areaFraction(k,iCell))*grav*(alphaT(k,iCell) &
+                   (1.0_RKIND - areaFraction(k,iCell))*grav*MtoCM*(alphaT(k,iCell) &
                    *tumd(k,iCell)**2.0_RKIND - betaS(k,iCell)*tumd(k,iCell)*sumd(k,iCell))
                  wttend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(ut(i1,k,iCell)*Uz + &
                    vt(i1,k,iCell)*Vz) - Mc(k,iCell)*wumd(k,iCell)*Tz
-                 wttend5(k,iCell) = kappa_FL*(wt(i1,k-1,iCell) -       &
+                 wttend5(k,iCell) = kappa_FL*MtoCM*MtoCM*(wt(i1,k-1,iCell) -       &
                    wt(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
                  wttend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
                    tumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
@@ -552,12 +560,12 @@ module ocn_adc_mixing_fused
                    wumd(k-1,iCell)*sumd(k-1,iCell)*Mc(k-1,iCell) - (1.0_RKIND - 2.0_RKIND* &
                    areaFraction(k+1,iCell))*wumd(k+1,iCell)*sumd(k+1,iCell)*Mc(k+1,iCell)) &
                    / (ze(k-1,iCell) - ze(k+1,iCell)) - Mc(k,iCell)*wumd(k,iCell)*Sz
-                 wstend3(k,iCell) = (1.0_RKIND - C_b_tracer)*grav*areaFraction(k,iCell)* &
+                 wstend3(k,iCell) = (1.0_RKIND - C_b_tracer)*grav*MtoCM*areaFraction(k,iCell)* &
                    (1.0_RKIND - areaFraction(k,iCell))*(alphaT(k,iCell) &
                    *tumd(k,iCell)*sumd(k,iCell) - betaS(k,iCell)*sumd(k,iCell)*sumd(k,iCell))
                  wstend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + &
                    vs(i1,k,iCell)*Vz)
-                 wstend5(k,iCell) = kappa_FL*(ws(i1,k-1,iCell) -       &
+                 wstend5(k,iCell) = kappa_FL*MtoCM*MtoCM*(ws(i1,k-1,iCell) -       &
                    ws(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
                  wstend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
                    sumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
@@ -581,10 +589,10 @@ module ocn_adc_mixing_fused
                    alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Uz
                  uwtend3(k,iCell) = 0.5_RKIND*(alpha_1 - alpha_2)*    &
                    uv(i1,k,iCell)*Vz
-                 uwtend4(k,iCell) = (1-C_b)*grav*(alphaT(k,iCell)*   &
+                 uwtend4(k,iCell) = (1-C_b)*grav*MtoCM*(alphaT(k,iCell)*   &
                    ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell))
                  uwtend5(k,iCell) = -tauVel(k,iCell)*uw(i1,k,iCell) + &
-                   kappa_FL*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
+                   kappa_FL*MtoCM*MtoCM*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  uwtend(i3_f,k,iCell) = uwtend1(k,iCell) + uwtend2(k,iCell) + &
@@ -599,9 +607,9 @@ module ocn_adc_mixing_fused
                    + 0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
                    (alpha_1 - alpha_2)*v2(i1,k,iCell) + (alpha_1 +   &
                    alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Vz + 0.5_RKIND*(alpha_1 &
-                   - alpha_2)*uv(i1,k,iCell)*Uz + (1-C_b)*grav*       &
+                   - alpha_2)*uv(i1,k,iCell)*Uz + (1-C_b)*grav*MtoCM*       &
                    (alphaT(k,iCell)*vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))) -            &
-                   tauVel(k,iCell)*vw(i1,k,iCell) + kappa_FL*(vw(i1,k-1,iCell) &
+                   tauVel(k,iCell)*vw(i1,k,iCell) + kappa_FL*MtoCM*MtoCM*(vw(i1,k-1,iCell) &
                    - vw(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  if (config_adc_truncate_tend) then
@@ -612,7 +620,7 @@ module ocn_adc_mixing_fused
                  uvtend(i3_f,k,iCell) = (-(uvw(k-1,iCell) - uvw(k,iCell)) / dz - &
                    (1.0_RKIND - 0.5_RKIND*(alpha_1+alpha_2))*(uw(i1,k,iCell)*Vz &
                    + vw(i1,k,iCell)*Uz)) - tauVel(k,iCell)*uv(i1,k,iCell) +           &
-                   kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) /       &
+                   kappa_VAR*MtoCM*MtoCM*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) /       &
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  if (config_adc_truncate_tend) then
@@ -719,7 +727,7 @@ module ocn_adc_mixing_fused
                       (zm(k-1,iCell) - zm(k,iCell)) &
                       - 2.88_RKIND/(tau + 1.0E-10_RKIND)*vw(i1,k,iCell)*(vvel(k-1,iCell) - vvel(k,iCell)) / &
                       (zm(k-1,iCell) - zm(k,iCell)) &
-                      + 2.88_RKIND/(tau + 1.0E-10_RKIND)*grav*(alphaT(k,iCell)*wt(i1,k,iCell) - betaS(k,iCell)* &
+                      + 2.88_RKIND/(tau + 1.0E-10_RKIND)*grav*MtoCM*(alphaT(k,iCell)*wt(i1,k,iCell) - betaS(k,iCell)* &
                       ws(i1,k,iCell)) - 3.84_RKIND*eps(i1,k,iCell)/(tau + 1.0E-10_RKIND)
                  endif
 
@@ -748,7 +756,7 @@ module ocn_adc_mixing_fused
                     Cval = (0.19_RKIND+0.51_RKIND*lenspsU(k,iCell)/dzmid)
                  endif
 
-                 KspsUtend(i3_f,k,iCell) = grav*(alphaT(k,iCell)*wt_spsU(k,iCell) - &
+                 KspsUtend(i3_f,k,iCell) = grav*MtoCM*(alphaT(k,iCell)*wt_spsU(k,iCell) - &
                    betaS(k,iCell)*ws_spsU(k,ICell)) + ((KmU(k-1,iCell) +                 &
                    KmU(k,iCell))*(KspsU(i1,k-1,iCell) - KspsU(i1,k,iCell)) /         &
                    (ze(k-1,iCell) - ze(k,iCell)) - (KmU(k,iCell) +             &
@@ -764,12 +772,12 @@ module ocn_adc_mixing_fused
                  endif
 
                  if(k==2) then
-                    Cval = 3.96_RKIND_RKIND
+                    Cval = 3.96_RKIND
                  else
                     Cval = (0.19_RKIND+0.51_RKIND*lenspsD(k,iCell)/dz)
                  endif
 
-                 KspsDtend(i3_f,k,iCell) = grav*(alphaT(k,iCell)*wt_spsD(k,iCell) - &
+                 KspsDtend(i3_f,k,iCell) = grav*MtoCM*(alphaT(k,iCell)*wt_spsD(k,iCell) - &
                    betaS(k,iCell)*ws_spsD(k,iCell)) + ((KmD(k-1,iCell) +                 &
                    KmD(k,iCell))*(KspsD(i1,k-1,iCell) - KspsD(i1,k,iCell)) /         &
                    (ze(k-1,iCell) - ze(k,iCell)) - (KmD(k,iCell) +             &
@@ -794,30 +802,30 @@ module ocn_adc_mixing_fused
                  w2(i2,k,iCell) = (w2(i1,k,iCell) + dt_small*(Cw3 * w2tend(i3_f,k,iCell)  &
                    + Cw2 * w2tend(i2_f,k,iCell) + Cw1 * w2tend(i1_f,k,iCell))) /           &
                    (1.0_RKIND + dt_small*tauvVel(k,iCell)*2.0_RKIND/3.0_RKIND)
-                 if(w2(i2,k,iCell) < epsilon) then
-                    w2cliptend(k,iCell) = epsilon - w2(i2,k,iCell)
-                    w2(i2,k,iCell) = epsilon
+                 if(w2(i2,k,iCell) < epsilon*MtoCM*MtoCM) then
+                    w2cliptend(k,iCell) = epsilon*MtoCM*MtoCM - w2(i2,k,iCell)
+                    w2(i2,k,iCell) = epsilon*MtoCM*MtoCM
                  endif
 
-                 if(abs(w2(i2,k,iCell)) > 1.0_RKIND) then
+                 if(abs(w2(i2,k,iCell)) > 1.0_RKIND*MtoCM*MtoCM) then
                     call mpas_log_write("ERROR: w2 out of range, w2 = $r, location = $i, $i", &
-                    MPAS_LOG_CRIT,realArgs=(/w2(i2,k,iCell)/),intArgs=(/k,iCell/))
+                      MPAS_LOG_CRIT,realArgs=(/w2(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
 
                  u2(i2,k,iCell) = (u2(i1,k,iCell) + dt_small*(Cw3 * u2tend(i3_f,k,iCell) +  &
                    Cw2 * u2tend(i2_f,k,iCell) + Cw1 * u2tend(i1_f,k,iCell))) /          &
                    (1.0_RKIND + dt_small*tauVel(k,iCell)*2.0_RKIND/3.0_RKIND)
-                 if(u2(i2,k,iCell) < epsilon) then
-                    u2cliptend(k,iCell) = epsilon - u2(i2,k,iCell)
-                    u2(i2,k,iCell) = epsilon
+                 if(u2(i2,k,iCell) < epsilon*MtoCM*MtoCM) then
+                    u2cliptend(k,iCell) = epsilon*MtoCM*MtoCM - u2(i2,k,iCell)
+                    u2(i2,k,iCell) = epsilon*MtoCM*MtoCM
                  endif
 
                  v2(i2,k,iCell) = (v2(i1,k,iCell) + dt_small*(Cw3 * v2tend(i3_f,k,iCell) + &
                    Cw2 * v2tend(i1_f,k,iCell) + Cw1 * v2tend(i1_f,k,iCell))) /              &
                    (1.0_RKIND + dt_small*tauVel(k,iCell)*2.0_RKIND/3.0_RKIND)
-                 if(v2(i2,k,iCell) < epsilon) then
-                    v2cliptend(k,iCell) = epsilon - v2(i2,k,iCell)
-                    v2(i2,k,iCell) = epsilon
+                 if(v2(i2,k,iCell) < epsilon*MtoCM*MtoCM) then
+                    v2cliptend(k,iCell) = epsilon*MtoCM*MtoCM - v2(i2,k,iCell)
+                    v2(i2,k,iCell) = epsilon*MtoCM*MtoCM
                  endif
 
                  uw(i2,k,iCell) = uw(i1,k,iCell) + dt_small*(Cw3 * uwtend(i3_f,k,iCell) + &
@@ -840,22 +848,22 @@ module ocn_adc_mixing_fused
                  ws(i2,k,iCell) = (ws(i1,k,iCell) + dt_small*(Cw3 * wstend(i3_f,k,iCell) + &
                    Cw2 * wstend(i2_f,k,iCell) + Cw1 * wstend(i1_f,k,iCell))) /              &
                    (1.0_RKIND + dt_small*tau_tracer(k,iCell))
-                 if(abs(wt(i2,k,iCell)) > 1.0_RKIND) then
+                 if(abs(wt(i2,k,iCell)) > 1.0_RKIND*MtoCM) then
                     call mpas_log_write("ERROR: wt out of range, wt = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/wt(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
                  
-                 if(abs(ws(i2,k,iCell)) > 1.0_RKIND) then
+                 if(abs(ws(i2,k,iCell)) > 1.0_RKIND*MtoCM) then
                     call mpas_log_write("ERROR: ws out of range, ws = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/ws(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
                  
-                 if(abs(u2(i2,k,iCell)) > 1.0_RKIND) then
+                 if(abs(u2(i2,k,iCell)) > 1.0_RKIND*MtoCM*MtoCM) then
                     call mpas_log_write("ERROR: u2 out of range, u2 = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/u2(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
 
-                 if(abs(v2(i2,k,iCell)) > 1.0_RKIND) then
+                 if(abs(v2(i2,k,iCell)) > 1.0_RKIND*MtoCM*MtoCM) then
                     call mpas_log_write("ERROR: v2 out of range, v2 = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/v2(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
@@ -874,10 +882,10 @@ module ocn_adc_mixing_fused
                     KE = 0.5_RKIND*(u2(i2,k,iCell) + v2(i2,k,iCell) + w2(i2,k,iCell))
                     eps(:,k,iCell) = KE**1.5_RKIND / (c_epsilon * length(k,iCell))
                  endif
-                 KspsU(i2,k,iCell) = max(epsilon,KspsU(i1,k,iCell) + dt_small*(Cw3 * &
+                 KspsU(i2,k,iCell) = max(epsilon*MtoCM*MtoCM,KspsU(i1,k,iCell) + dt_small*(Cw3 * &
                    KspsUtend(i3_f,k,iCell) + Cw2 * KspsUtend(i2_f,k,iCell) + Cw1 *    &
                    KspsUtend(i1_f,k,iCell)))
-                 KspsD(i2,k,iCell) = max(epsilon,KspsD(i1,k,iCell) + dt_small*(Cw3 * &
+                 KspsD(i2,k,iCell) = max(epsilon*MtoCM*MtoCM,KspsD(i1,k,iCell) + dt_small*(Cw3 * &
                    KspsDtend(i3_f,k,iCell) + Cw2 * KspsDtend(i2_f,k,iCell) + Cw1 *    &
                    KspsDtend(i1_f,k,iCell)))
 
@@ -888,13 +896,13 @@ module ocn_adc_mixing_fused
            do iCell = 1,nCells
               do k=1,nVertLevels
                  w3check = (w2(i2,k,iCell) + w2(i2,k+1,iCell))**1.5_RKIND
-                 if(w3check < 3e-14_RKIND) w3check = 1.0_RKIND
+                 if(w3check < 3e-14_RKIND*MtoCM*MtoCM*MtoCM) w3check = 1.0_RKIND*MtoCM*MtoCM*MtoCM
                  w3(i2,k,iCell) = max(-w3check,min((w3(i1,k,iCell) + dt_small*(Cw3 * w3tend(i3_f,k,iCell) + &
                    Cw2 * w3tend(i2_f,k,iCell) + Cw1 * w3tend(i1_f,k,iCell))) / &
                    (1.0_RKIND + 0.0_RKIND*dt_small*tauw3(k,iCell)),w3check))
 
 
-                 if(abs(w3(i2,k,iCell)) > 1.0_RKIND) then
+                 if(abs(w3(i2,k,iCell)) > 1.0_RKIND*MtoCM*MtoCM*MtoCM) then
                     call mpas_log_write("ERROR: w3 out of range, w3 = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/w3(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -183,9 +183,10 @@ module ocn_adc_mixing_fused
       real(kind=RKIND),dimension(nVertLevels,nCells) :: areaFractionMid, tumdMid, McMid, wumdMid, sumdMid
 
       real(kind=RKIND) :: SwU, SwD, tau_sfc, d_sqrt_wp2_dz, tp2, sp2, min_wp2_sfc_val, wp2_splat_sfc_correction
-      real(kind=RKIND) :: min_wps_sfc_val
+      real(kind=RKIND) :: min_wps_sfc_val, adcRound
 
       min_wps_sfc_val = 1.0E-10_RKIND
+      adcRound = 10.0_RKIND**config_adc_decimals_to_keep
       dt_small = config_adc_timestep
       niter = dt / dt_small
 
@@ -446,8 +447,8 @@ module ocn_adc_mixing_fused
                  endif
 
                  if (config_adc_truncate_tend) then
-                    w3tend(i3_f,k,iCell) = FLOAT (INT(w3tend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    w3tend(i3_f,k,iCell) = FLOAT (INT(w3tend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
 !     now get all the downgradient TOMs
@@ -509,8 +510,8 @@ module ocn_adc_mixing_fused
                    w2tend3(k,iCell) + w2tend4(k,iCell) + w2tend5(k,iCell) + w2tend6(k,iCell)
 
                  if (config_adc_truncate_tend) then
-                    w2tend(i3_f,k,iCell) = FLOAT (INT(w2tend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    w2tend(i3_f,k,iCell) = FLOAT (INT(w2tend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  wttend1(k,iCell) = -1.0_RKIND*(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
@@ -536,8 +537,8 @@ module ocn_adc_mixing_fused
                    wttend3(k,iCell) + wttend4(k,iCell) + wttend5(k,iCell) + wttend6(k,iCell)
 
                  if (config_adc_truncate_tend) then
-                    wttend(i3_f,k,iCell) = FLOAT (INT(wttend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    wttend(i3_f,k,iCell) = FLOAT (INT(wttend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  wstend1(k,iCell) = -(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
@@ -565,8 +566,8 @@ module ocn_adc_mixing_fused
                    wstend3(k,iCell) + wstend4(k,iCell) + wstend5(k,iCell) + wstend6(k,iCell)
 
                  if (config_adc_truncate_tend) then
-                    wstend(i3_f,k,iCell) = FLOAT (INT(wstend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    wstend(i3_f,k,iCell) = FLOAT (INT(wstend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  uwtend1(k,iCell) = -(uw2(k-1,iCell) - uw2(k,iCell)) / dzmid
@@ -585,8 +586,8 @@ module ocn_adc_mixing_fused
                    uwtend3(k,iCell) + uwtend4(k,iCell) + uwtend5(k,iCell)
 
                  if (config_adc_truncate_tend) then
-                    uwtend(i3_f,k,iCell) = FLOAT (INT(uwtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    uwtend(i3_f,k,iCell) = FLOAT (INT(uwtend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  vwtend(i3_f,k,iCell) = (-(vw2(k-1,iCell) - vw2(k,iCell)) / dzmid  &
@@ -599,8 +600,8 @@ module ocn_adc_mixing_fused
                    - vw(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  if (config_adc_truncate_tend) then
-                    vwtend(i3_f,k,iCell) = FLOAT (INT(vwtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    vwtend(i3_f,k,iCell) = FLOAT (INT(vwtend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  uvtend(i3_f,k,iCell) = (-(uvw(k-1,iCell) - uvw(k,iCell)) / dz - &
@@ -610,8 +611,8 @@ module ocn_adc_mixing_fused
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  if (config_adc_truncate_tend) then
-                    uvtend(i3_f,k,iCell) = FLOAT (INT(uvtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    uvtend(i3_f,k,iCell) = FLOAT (INT(uvtend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  u2tend1(k,iCell) = -(u2w(k-1,iCell) - u2w(k,iCell)) / dzmid
@@ -627,8 +628,8 @@ module ocn_adc_mixing_fused
                    u2tend3(k,iCell) + u2tend4(k,iCell) + u2tend5(k,iCell) + u2tend6(k,iCell)
 
                  if (config_adc_truncate_tend) then
-                    u2tend(i3_f,k,iCell) = FLOAT (INT(u2tend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    u2tend(i3_f,k,iCell) = FLOAT (INT(u2tend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
                 
                  v2tend1(k,iCell) = -(v2w(k-1,iCell) - v2w(k,iCell)) / dzmid
@@ -644,8 +645,8 @@ module ocn_adc_mixing_fused
                    v2tend3(k,iCell) + v2tend4(k,iCell) + v2tend5(k,iCell) + v2tend6(k,iCell)
 
                  if (config_adc_truncate_tend) then
-                    v2tend(i3_f,k,iCell) = FLOAT (INT(v2tend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    v2tend(i3_f,k,iCell) = FLOAT (INT(v2tend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  uttend(i3_f,k,iCell) = (-(uwt(k-1,iCell) - uwt(k,iCell))/dz -  &
@@ -653,8 +654,8 @@ module ocn_adc_mixing_fused
                    alpha_tracer2))*wt(i1,k,iCell)*Uz) - ut(i1,k,iCell)*tau_tracer(k,iCell)
 
                  if (config_adc_truncate_tend) then
-                    uttend(i3_f,k,iCell) = FLOAT (INT(uttend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    uttend(i3_f,k,iCell) = FLOAT (INT(uttend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  vttend(i3_f,k,iCell) = (-(vwt(k-1,iCell) - vwt(k,iCell))/dz -  &
@@ -662,8 +663,8 @@ module ocn_adc_mixing_fused
                    alpha_tracer2))*wt(i1,k,iCell)*Vz) - vt(i1,k,iCell)*tau_tracer(k,iCell)
 
                  if (config_adc_truncate_tend) then
-                    vttend(i3_f,k,iCell) = FLOAT (INT(vttend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    vttend(i3_f,k,iCell) = FLOAT (INT(vttend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  ustend(i3_f,k,iCell) = (-(uws(k-1,iCell) - uws(k,iCell))/dz -  &
@@ -671,8 +672,8 @@ module ocn_adc_mixing_fused
                    alpha_tracer2))*ws(i1,k,iCell)*Uz) - us(i1,k,iCell)*tau_tracer(k,ICell)
                  
                  if (config_adc_truncate_tend) then
-                    ustend(i3_f,k,iCell) = FLOAT (INT(ustend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    ustend(i3_f,k,iCell) = FLOAT (INT(ustend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  vstend(i3_f,k,iCell) = (-(vws(k-1,iCell) - vws(k,iCell))/dz -  &
@@ -680,8 +681,8 @@ module ocn_adc_mixing_fused
                    alpha_tracer2))*ws(i1,k,iCell)*Vz) - vs(i1,k,iCell)*tau_tracer(k,iCell)
 
                  if (config_adc_truncate_tend) then
-                    vstend(i3_f,k,iCell) = FLOAT (INT(vstend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    vstend(i3_f,k,iCell) = FLOAT (INT(vstend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  t2(i2,k,iCell) = tumd(k,iCell)**2.0_RKIND*areaFraction(k,iCell)*&
@@ -753,8 +754,8 @@ module ocn_adc_mixing_fused
                    (Uz**2.0_RKIND + Vz**2.0_RKIND)
 
                  if (config_adc_truncate_tend) then
-                    KspsUtend(i3_f,k,iCell) = FLOAT (INT(KspsUtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    KspsUtend(i3_f,k,iCell) = FLOAT (INT(KspsUtend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
                  if(k==2) then
@@ -774,8 +775,8 @@ module ocn_adc_mixing_fused
                    KmD(k,iCell)*(Uz**2.0_RKIND + Vz**2.0_RKIND)
 
                  if (config_adc_truncate_tend) then
-                    KspsDtend(i3_f,k,iCell) = FLOAT (INT(KspsDtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
-                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                    KspsDtend(i3_f,k,iCell) = FLOAT (INT(KspsDtend(i3_f,k,iCell) * adcRound &
+                      + 0.5_RKIND)) / adcRound
                  endif
 
               enddo           ! nVertLevels

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -18,34 +18,34 @@ module ocn_adc_mixing_fused
 
   subroutine get_array_pointers
 
-    i1 = mod(iterCount - 1, 2) + 1
-    i2 = mod(iterCount, 2) + 1
-
-    i3_f = mod(iterCount+2, 3) + 1 ! {3,1,2}
-    i2_f = mod(iterCount+1, 3) + 1 ! {2,3,1}
-    i1_f = mod(iterCount  , 3) + 1 ! {1,2,3}
-
+      i1 = mod(iterCount - 1, 2) + 1
+      i2 = mod(iterCount, 2) + 1
+      
+      i3_f = mod(iterCount+2, 3) + 1 ! {3,1,2}
+      i2_f = mod(iterCount+1, 3) + 1 ! {2,3,1}
+      i1_f = mod(iterCount  , 3) + 1 ! {1,2,3}
+      
   end subroutine get_array_pointers
 
   subroutine get_weights
 
-    real (kind=RKIND) :: w3_ab3 = 1.91666666667_RKIND, &
-                         w2_ab3 = -1.3333333333_RKIND, &
-                         w1_ab3 = 0.41666666667_RKIND
+      real (kind=RKIND) :: w3_ab3 = 1.91666666667_RKIND, &
+        w2_ab3 = -1.3333333333_RKIND, &
+        w1_ab3 = 0.41666666667_RKIND
 
-    if (iterCount <= 1) then
-      Cw3 = 1.0_RKIND
-      Cw2 = 0.0_RKIND
-      Cw1 = 0.0_RKIND
-    elseif (iterCount == 2) then
-      Cw3 = 1.5_RKIND
-      Cw2 = -0.5_RKIND
-      Cw1 = 0.0_RKIND
-    else
-      Cw3 = w3_ab3
-      Cw2 = w2_ab3
-      Cw1 = w1_ab3
-    endif
+      if (iterCount <= 1) then
+         Cw3 = 1.0_RKIND
+         Cw2 = 0.0_RKIND
+         Cw1 = 0.0_RKIND
+      elseif (iterCount == 2) then
+         Cw3 = 1.5_RKIND
+         Cw2 = -0.5_RKIND
+         Cw1 = 0.0_RKIND
+      else
+         Cw3 = w3_ab3
+         Cw2 = w2_ab3
+         Cw1 = w1_ab3
+      endif
 
   end subroutine get_weights
 
@@ -157,35 +157,35 @@ module ocn_adc_mixing_fused
                   uwsfc, vwsfc, wtsfc, wssfc, alphaT, betaS, fCell, boundaryLayerDepth)
 
       integer,intent(in) :: nCells, nVertLevels, nTracers
-      real,intent(in) :: dt
+      real(kind=RKIND),intent(in) :: dt
 
-      real,dimension(nTracers,nVertLevels,nCells),intent(inout) :: activeTracers
-      real,dimension(nVertLevels,nCells),intent(inout) :: uvel, vvel, alphaT, betaS
-      real,dimension(nCells),intent(in) :: uwsfc, vwsfc, wtsfc, wssfc, fCell
-      real,dimension(nCells),intent(in) :: boundaryLayerDepth
-      real,dimension(nVertLevels,nCells),intent(inout) :: BVF
+      real(kind=RKIND),dimension(nTracers,nVertLevels,nCells),intent(inout) :: activeTracers
+      real(kind=RKIND),dimension(nVertLevels,nCells),intent(inout) :: uvel, vvel, alphaT, betaS
+      real(kind=RKIND),dimension(nCells),intent(in) :: uwsfc, vwsfc, wtsfc, wssfc, fCell
+      real(kind=RKIND),dimension(nCells),intent(in) :: boundaryLayerDepth
+      real(kind=RKIND),dimension(nVertLevels,nCells),intent(inout) :: BVF
       integer :: niter, iIter,iCell,k, supercycle
 
-      real :: dt_small
+      real(kind=RKIND) :: dt_small
 
-      real :: Sw, St, Ss, Eav, Dav, sigav, sigavp1, wumdAv, tumdAv, sumdAv, wumdAvp1, tumdAvp1, sumdAvp1
-      real :: Swup, KspsUav, KspsDav, KspsUavp1, KspsDavp1, KE, Mcav, lenav,u2av,v2av,w2av
-      real :: w2tTemp, w2tCheck, w2sTemp, w2sCheck, w3temp, w3check2, w3check, mval, KEsps, Uz, Vz, dz
+      real(kind=RKIND) :: Sw, St, Ss, Eav, Dav, sigav, sigavp1, wumdAv, tumdAv, sumdAv, wumdAvp1, tumdAvp1, sumdAvp1
+      real(kind=RKIND) :: Swup, KspsUav, KspsDav, KspsUavp1, KspsDavp1, KE, Mcav, lenav,u2av,v2av,w2av
+      real(kind=RKIND) :: w2tTemp, w2tCheck, w2sTemp, w2sCheck, w3temp, w3check2, w3check, mval, KEsps, Uz, Vz, dz
 
-      real :: invLen, l, len1, len2, lenmax, integrandTop, integrandBot
-      real :: len0, len2_1, len2_2, sfcBuoy, lengthT, bvfT
-      real :: KEm1, KEp1, tauUP, tauDN, tomUP, tomDN
-      real :: tauM1, tau, tauP1, tauAV, utemp, vtemp
-      real :: B, Cval, diff, wtav, dzmid, Ksps, Sz, Tz, w4k, w4kp1, w2k, w2kp1
-      real :: lareaFraction, wstar, Q, w3av, tempMoment, frictionVelocity
-      real :: sfcFrictionVelocitySquared, wtSumUp, wtSumDn, wsSumUp, wsSumDn
+      real(kind=RKIND) :: invLen, l, len1, len2, lenmax, integrandTop, integrandBot
+      real(kind=RKIND) :: len0, len2_1, len2_2, sfcBuoy, lengthT, bvfT
+      real(kind=RKIND) :: KEm1, KEp1, tauUP, tauDN, tomUP, tomDN
+      real(kind=RKIND) :: tauM1, tau, tauP1, tauAV, utemp, vtemp
+      real(kind=RKIND) :: B, Cval, diff, wtav, dzmid, Ksps, Sz, Tz, w4k, w4kp1, w2k, w2kp1
+      real(kind=RKIND) :: lareaFraction, wstar, Q, w3av, tempMoment, frictionVelocity
+      real(kind=RKIND) :: sfcFrictionVelocitySquared, wtSumUp, wtSumDn, wsSumUp, wsSumDn
 
-      real,dimension(nVertLevels,nCells) :: Swumd
-      real,dimension(nVertLevels,nCells) :: tauw3, tau_tracer, tauVel, tauvVel
-      real,dimension(nVertLevels,nCells) :: areaFractionMid, tumdMid, McMid, wumdMid, sumdMid
+      real(kind=RKIND),dimension(nVertLevels,nCells) :: Swumd
+      real(kind=RKIND),dimension(nVertLevels,nCells) :: tauw3, tau_tracer, tauVel, tauvVel
+      real(kind=RKIND),dimension(nVertLevels,nCells) :: areaFractionMid, tumdMid, McMid, wumdMid, sumdMid
 
-      real :: Swk, tau_sfc, d_sqrt_wp2_dz, tp2, sp2, min_wp2_sfc_val, wp2_splat_sfc_correction
-      real :: min_wps_sfc_val
+      real(kind=RKIND) :: SwU, SwD, tau_sfc, d_sqrt_wp2_dz, tp2, sp2, min_wp2_sfc_val, wp2_splat_sfc_correction
+      real(kind=RKIND) :: min_wps_sfc_val
 
       min_wps_sfc_val = 1.0E-10_RKIND
       dt_small = config_adc_timestep
@@ -202,9 +202,9 @@ module ocn_adc_mixing_fused
             Q = grav*(alphaT(1,iCell)*wtsfc(iCell) - betaS(1,iCell)*wssfc(iCell))* &
               boundaryLayerDepth(iCell)
               if(Q > 0) then
-                 wstar = abs(Q)**(1.0/3.0)
+                 wstar = abs(Q)**(1.0_RKIND/3.0_RKIND)
               else
-                 wstar = 0.0
+                 wstar = 0.0_RKIND
               endif
 
               tumd(1,iCell) = 0.0_RKIND
@@ -218,15 +218,15 @@ module ocn_adc_mixing_fused
               frictionVelocity = sqrt(sfcFrictionVelocitySquared + config_adc_bc_wstar * wstar * wstar)
               frictionVelocity = max( config_adc_frictionVelocityMin, frictionVelocity )
               do k=1,3
-                 u2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0
-                 v2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0
-                 w2(k,1,iCell) = config_adc_bc_const_wp2*frictionVelocity**2.0
+                 u2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
+                 v2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
+                 w2(k,1,iCell) = config_adc_bc_const_wp2*frictionVelocity**2.0_RKIND
                  uw(k,1,iCell) = -uwsfc(iCell)
                  vw(k,1,iCell) = -vwsfc(iCell)
                  wt(k,1,iCell) = wtsfc(iCell)
                  ws(k,1,iCell) = wssfc(iCell)
-                 KE = 0.5*(u2(i1,1,iCell) + v2(i1,1,iCell))
-                 eps(k,1,iCell) = KE**1.5/(0.5*(ze(1,iCell) - ze(2,iCell) + 1.0E-10_RKIND))
+                 KE = 0.5_RKIND*(u2(i1,1,iCell) + v2(i1,1,iCell))
+                 eps(k,1,iCell) = KE**1.5_RKIND/(0.5_RKIND*(ze(1,iCell) - ze(2,iCell) + 1.0E-10_RKIND))
               enddo
            enddo
 
@@ -337,7 +337,7 @@ module ocn_adc_mixing_fused
                  tumd(k,iCell) = wt(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
                  sumd(k,iCell) = ws(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
 
-                 if(w2(i1,k,iCell) <= epsilon + 1.0e-9) then
+                 if(w2(i1,k,iCell) <= epsilon + 1.0e-9_RKIND) then
                     tumd(k,iCell) = 0.0_RKIND
                     sumd(k,iCell) = 0.0_RKIND
                  endif
@@ -367,12 +367,12 @@ module ocn_adc_mixing_fused
                  sumdav = sumdMid(k,iCell)
                  w2tTemp = -sigav*(1.0_RKIND - sigav)*(1.0_RKIND - 2.0_RKIND*sigav)*wumdav**2.0_RKIND*tumdav
                  w2tCheck = sigav*(1.0_RKIND - sigav)*sqrt(1.0_RKIND - 3.0_RKIND*sigav + 3.0_RKIND*sigav**2)* &
-                   wumdav**2.0*tumdav
+                   wumdav**2.0_RKIND*tumdav
                  w2t(k,iCell) = w2tTemp
 
                  w2sTemp = -sigav*(1.0_RKIND - sigav)*(1.0_RKIND - 2.0_RKIND*sigav)*wumdav**2.0_RKIND*sumdav
                  w2sCheck = sigav*(1.0_RKIND - sigav)*sqrt(1.0_RKIND - 3.0_RKIND*sigav + 3.0_RKIND*sigav**2)* &
-                   wumdav**2.0*sumdav
+                   wumdav**2.0_RKIND*sumdav
                  w2s(k,iCell) = w2sTemp
 
 !     also use this loop to reset the cliptends for the step
@@ -397,22 +397,22 @@ module ocn_adc_mixing_fused
 !     This cell loop computes w3Tend and TOMs for later tendencies.  Should be okay to collapse loops here
            do iCell = 1,nCells
               do k=1,nVertLevels
-                 Eav = 0.5*(Entrainment(k+1,iCell) + Entrainment(k,iCell))
-                 Dav = 0.5*(Detrainment(k+1,iCell) + Detrainment(k,iCell))
-                 u2av = 0.5*(u2(i1,k,iCell) + u2(i1,k+1,iCell))
-                 v2av = 0.5*(v2(i1,k,iCell) + v2(i1,k+1,iCell))
-                 w2av = 0.5*(w2(i1,k,iCell) + w2(i1,k+1,iCell))
+                 Eav = 0.5_RKIND*(Entrainment(k+1,iCell) + Entrainment(k,iCell))
+                 Dav = 0.5_RKIND*(Detrainment(k+1,iCell) + Detrainment(k,iCell))
+                 u2av = 0.5_RKIND*(u2(i1,k,iCell) + u2(i1,k+1,iCell))
+                 v2av = 0.5_RKIND*(v2(i1,k,iCell) + v2(i1,k+1,iCell))
+                 w2av = 0.5_RKIND*(w2(i1,k,iCell) + w2(i1,k+1,iCell))
 
-                 sigav = 0.5*(areaFraction(k,iCell) + areaFraction(k+1,iCell))
-                 wumdav = 0.5*(wumd(k,iCell) + wumd(k+1,iCell))
-                 tumdav = 0.5*(tumd(k,iCell) + tumd(k+1,iCell))
-                 sumdav = 0.5*(sumd(k,iCell) + sumd(k+1,iCell))
-                 Mcav = 0.5*(Mc(k,iCell) + Mc(k+1,iCell))
-                 lenav = 0.5*(length(k,iCell) + length(k+1,iCell))
+                 sigav = 0.5_RKIND*(areaFraction(k,iCell) + areaFraction(k+1,iCell))
+                 wumdav = 0.5_RKIND*(wumd(k,iCell) + wumd(k+1,iCell))
+                 tumdav = 0.5_RKIND*(tumd(k,iCell) + tumd(k+1,iCell))
+                 sumdav = 0.5_RKIND*(sumd(k,iCell) + sumd(k+1,iCell))
+                 Mcav = 0.5_RKIND*(Mc(k,iCell) + Mc(k+1,iCell))
+                 lenav = 0.5_RKIND*(length(k,iCell) + length(k+1,iCell))
                  KE = sqrt(0.5_RKIND*(u2av+v2av+w2av))
 
                  dz = ze(k,iCell) - ze(k+1,iCell)
-                 Swumd(k,iCell) = - 2.0/3.0*(1.0_RKIND/sigav*(areaFraction(k,iCell)*KspsD(i1,k,iCell) - &
+                 Swumd(k,iCell) = - 2.0_RKIND/3.0_RKIND*(1.0_RKIND/sigav*(areaFraction(k,iCell)*KspsD(i1,k,iCell) - &
                    areaFraction(k+1,iCell)*KspsD(i1,k+1,iCell)) / dz - 1.0_RKIND / (1.0_RKIND - &
                    sigav)*((1.0_RKIND - areaFraction(k,iCell))*KspsU(i1,k,iCell) - (1.0_RKIND - &
                    areaFraction(k+1,iCell))*KspsU(i1,k+1,iCell)) / dz)
@@ -423,12 +423,16 @@ module ocn_adc_mixing_fused
                  sigav = areaFractionMid(k,iCell)
                  Mcav = McMid(k,iCell)
                  
-                 w3tend1(k,iCell) = -wumdav**3.0*(Eav*(3.0*sigav - 2.0) + Dav*(3.0*sigav - 1.0))
+                 w3tend1(k,iCell) = -wumdav**3.0_RKIND*(Eav*(3.0_RKIND*sigav - 2.0_RKIND) &
+                   + Dav*(3.0_RKIND*sigav - 1.0_RKIND))
 
-                 Swk   =  -(1.0_RKIND-2.0_RKIND*sigav)/(sigav*(1.0_RKIND-sigav))**0.5
-                 w3tend2(k,iCell) = -((3.0_RKIND + Swk**2.0)*(w2(i1,k,iCell)**2.0) - &
-                   (3.0_RKIND + Swk**2.0)*(w2(i1,k+1,iCell)**2.0) ) / dz
-                 w3tend3(k,iCell) = 1.5_RKIND*(w2(i1,k,iCell)**2.0 - w2(i1,k+1,iCell)**2.0) / dz
+                 SwU = -(1.0_RKIND-2.0_RKIND*areaFraction(k,iCell))
+                   /(areaFraction(k,iCell)*(1.0_RKIND-areaFraction(k,iCell)))**0.5_RKIND
+                 SwD = -(1.0_RKIND-2.0_RKIND*areaFraction(k+1,iCell))
+                   /(areaFraction(k+1,iCell)*(1.0_RKIND-areaFraction(k+1,iCell)))**0.5_RKIND
+                 w3tend2(k,iCell) = -((3.0_RKIND + SwU**2.0_RKIND)*(w2(i1,k,iCell)**2.0_RKIND) - &
+                   (3.0_RKIND + SwD**2.0_RKIND)*(w2(i1,k+1,iCell)**2.0_RKIND) ) / dz
+                 w3tend3(k,iCell) = 1.5_RKIND*(w2(i1,k,iCell)**2.0_RKIND - w2(i1,k+1,iCell)**2.0_RKIND) / dz
 
                  w3tend4(k,iCell) = -3.0_RKIND*(1.0_RKIND - 2.0_RKIND*sigav)*Mcav*wumdav*Swumd(k,iCell) - &
                    tauw3(k,iCell)*w3(i1,k,iCell)
@@ -438,9 +442,9 @@ module ocn_adc_mixing_fused
                  w3tend(i3_f,k,iCell) = w3tend1(k,iCell) + w3tend2(k,iCell) + w3tend3(k,iCell) + &
                  w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell)
 
-                 if(k>1 .and. k < nVertLevels .and. kappa_w3 > 0.0) then
+                 if(k>1 .and. k < nVertLevels .and. kappa_w3 > 0.0_RKIND) then
                     w3tend(i3_f,k,iCell) = w3tend(i3_f,k,iCell) + kappa_w3*(w3(i1,k-1,iCell) &
-                      - w3(i1,k+1,iCell)) / (zm(k-1,iCell) - zm(k+1,iCell))**2.0
+                      - w3(i1,k+1,iCell)) / (zm(k-1,iCell) - zm(k+1,iCell))**2.0_RKIND
                  endif
 
 !     now get all the downgradient TOMs
@@ -455,7 +459,7 @@ module ocn_adc_mixing_fused
                  v2w(k,iCell) = -diff*(v2(i1,k,iCell) - v2(i1,k+1,iCell)) / dz
                  uvw(k,iCell) = -diff*(uv(i1,k,iCell) - uv(i1,k+1,iCell)) / dz
 
-                 diff = C_therm*sqrt(0.5*(KE + KEp1)) * lenav
+                 diff = C_therm*sqrt(0.5_RKIND*(KE + KEp1)) * lenav
                  uwt(k,iCell) = -diff*(ut(i1,k,iCell) - ut(i1,k+1,iCell)) / dz
                  vwt(k,iCell) = -diff*(vt(i1,k,iCell) - vt(i1,k+1,iCell)) / dz
                  uws(k,iCell) = -diff*(us(i1,k,iCell) - us(i1,k+1,iCell)) / dz
@@ -480,7 +484,7 @@ module ocn_adc_mixing_fused
                  Sz = (activeTracers(2,k-1,iCell) - activeTracers(2,k,iCell)) / dzmid
                  
                  KE = sqrt(0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + areaFraction(k,iCell)* &
-                   (1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2.0))
+                   (1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2.0_RKIND))
 
                  tau_tracer(k,iCell) = c_slow_tracer*KE / (1.0E-15_RKIND + length(k,iCell))
                  tauVel(k,iCell) = C_slow*KE / (1.0E-15_RKIND + length(k,iCell))
@@ -489,8 +493,8 @@ module ocn_adc_mixing_fused
                  w2tend1(k,iCell) = -wumd(k,iCell)**2.0_RKIND*(         &
                    Entrainment(k,iCell) + Detrainment(k,iCell))
                  w2tend2(k,iCell) = (McMid(k-1,iCell)*(1.0_RKIND - 2.0_RKIND* &
-                   areaFractionMid(k-1,iCell))*wumdMid(k-1,iCell)**2.0 - McMid(k,iCell)* &
-                   (1.0_RKIND - 2.0_RKIND*areaFractionMid(k,iCell))*wumdMid(k,iCell)**2.0) / dzmid
+                   areaFractionMid(k-1,iCell))*wumdMid(k-1,iCell)**2.0_RKIND - McMid(k,iCell)* &
+                   (1.0_RKIND - 2.0_RKIND*areaFractionMid(k,iCell))*wumdMid(k,iCell)**2.0_RKIND) / dzmid
                  w2tend3(k,iCell) = tauvVel(k,iCell)*(u2(i1,k,iCell) + v2(i1,k,iCell))/3.0_RKIND
                  w2tend4(k,iCell) = (2.0_RKIND - 4.0_RKIND/3.0_RKIND*C_b)*Mc(k,iCell)* &
                    (grav*alphaT(k,iCell)*tumd(k,iCell) - grav*betaS(k,iCell)*sumd(k,iCell))
@@ -511,11 +515,11 @@ module ocn_adc_mixing_fused
                    Mc(k,iCell)*wumd(k,iCell)*Tz*0.0_RKIND
                  wttend3(k,iCell) = (1.0_RKIND - C_b_tracer)*areaFraction(k,iCell)*  &
                    (1.0_RKIND - areaFraction(k,iCell))*grav*(alphaT(k,iCell) &
-                   *tumd(k,iCell)**2.0 - betaS(k,iCell)*tumd(k,iCell)*sumd(k,iCell))
+                   *tumd(k,iCell)**2.0_RKIND - betaS(k,iCell)*tumd(k,iCell)*sumd(k,iCell))
                  wttend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(ut(i1,k,iCell)*Uz + &
                    vt(i1,k,iCell)*Vz) - Mc(k,iCell)*wumd(k,iCell)*Tz
                  wttend5(k,iCell) = kappa_FL*(wt(i1,k-1,iCell) -       &
-                   wt(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0
+                   wt(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
                  wttend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
                    tumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
                    (1.0_RKIND / areaFraction(k,iCell) * (areaFraction(k-1,iCell)*wt_spsU(k-1,iCell) - &
@@ -539,7 +543,7 @@ module ocn_adc_mixing_fused
                  wstend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + &
                    vs(i1,k,iCell)*Vz)
                  wstend5(k,iCell) = kappa_FL*(ws(i1,k-1,iCell) -       &
-                   ws(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0
+                   ws(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
                  wstend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
                    sumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
                    (1.0_RKIND / areaFraction(k,iCell) * (areaFraction(k-1,iCell)*ws_spsU(k-1,iCell) - &
@@ -552,7 +556,7 @@ module ocn_adc_mixing_fused
                    wstend3(k,iCell) + wstend4(k,iCell) + wstend5(k,iCell) + wstend6(k,iCell)
 
                  uwtend1(k,iCell) = -(uw2(k-1,iCell) - uw2(k,iCell)) / dzmid
-                 uwtend2(k,iCell) = 0.5*((alpha_0 - 4.0*alpha_1/3.0)*KE**2.0 +  &
+                 uwtend2(k,iCell) = 0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
                    (alpha_1 - alpha_2)*u2(i1,k,iCell) + (alpha_1 +  &
                    alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Uz
                  uwtend3(k,iCell) = 0.5_RKIND*(alpha_1 - alpha_2)*    &
@@ -561,19 +565,19 @@ module ocn_adc_mixing_fused
                    ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell))
                  uwtend5(k,iCell) = -tauVel(k,iCell)*uw(i1,k,iCell) + &
                    kappa_FL*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
-                   (ze(k-1,iCell) - ze(k+1,iCell))**2.0
+                   (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  uwtend(i3_f,k,iCell) = uwtend1(k,iCell) + uwtend2(k,iCell) + &
                    uwtend3(k,iCell) + uwtend4(k,iCell) + uwtend5(k,iCell)
 
                  vwtend(i3_f,k,iCell) = (-(vw2(k-1,iCell) - vw2(k,iCell)) / dzmid  &
-                   + 0.5_RKIND*((alpha_0 - 4.0*alpha_1/3.0)*KE**2.0_RKIND +  &
+                   + 0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
                    (alpha_1 - alpha_2)*v2(i1,k,iCell) + (alpha_1 +   &
                    alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Vz + 0.5_RKIND*(alpha_1 &
                    - alpha_2)*uv(i1,k,iCell)*Uz + (1-C_b)*grav*       &
                    (alphaT(k,iCell)*vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))) -            &
                    tauVel(k,iCell)*vw(i1,k,iCell) + kappa_FL*(vw(i1,k-1,iCell) &
-                   - vw(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0
+                   - vw(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  uvtend(i3_f,k,iCell) = (-(uvw(k-1,iCell) - uvw(k,iCell)) / dz - &
                    (1.0_RKIND - 0.5_RKIND*(alpha_1+alpha_2))*(uw(i1,k,iCell)*Vz &
@@ -638,20 +642,20 @@ module ocn_adc_mixing_fused
                     tauP1 = 2.0_RKIND*KEp1 / (eps(i1,k+1,iCell) + 1.0E-15_RKIND)
                     tauAV = 0.5_RKIND*(tauUP + tauDN)
                     
-                    tomUP = 0.5577/1.3_RKIND*(0.5_RKIND*(KEm1+KE))**2/(0.5_RKIND*(eps(i1,k-1,iCell) + &
+                    tomUP = 0.5577_RKIND/1.3_RKIND*(0.5_RKIND*(KEm1+KE))**2/(0.5_RKIND*(eps(i1,k-1,iCell) + &
                       eps(i1,k,iCell)) + 1.0E-15_RKIND)*(eps(i1,k-1,iCell) - &
                       eps(i1,k,iCell)) / (ze(k-1,iCell) - ze(k,iCell) + 1.0E-10_RKIND)
-                    tomDN = 0.5577/1.3_RKIND*(0.5_RKIND*(KE+KEp1))**2/(0.5_RKIND*(eps(i1,k,iCell) + &
+                    tomDN = 0.5577_RKIND/1.3_RKIND*(0.5_RKIND*(KE+KEp1))**2/(0.5_RKIND*(eps(i1,k,iCell) + &
                       eps(i1,k+1,iCell)) + 1.0E-15_RKIND)*(eps(i1,k,iCell) - &
                       eps(i1,k+1,iCell)) / (ze(k,iCell) - ze(k+1,iCell) + 1.0E-10_RKIND)
                     
                     epstend(i3_f,k,iCell) = (tomUP - tomDN) / (zm(k-1,iCell) - zm(k,iCell) + 1.0E-10_RKIND) &
-                      - 2.88/(tau + 1.0E-10_RKIND)*uw(i1,k,iCell)*(uvel(k-1,iCell) - uvel(k,iCell)) / &
+                      - 2.88_RKIND/(tau + 1.0E-10_RKIND)*uw(i1,k,iCell)*(uvel(k-1,iCell) - uvel(k,iCell)) / &
                       (zm(k-1,iCell) - zm(k,iCell)) &
-                      - 2.88/(tau + 1.0E-10_RKIND)*vw(i1,k,iCell)*(vvel(k-1,iCell) - vvel(k,iCell)) / &
+                      - 2.88_RKIND/(tau + 1.0E-10_RKIND)*vw(i1,k,iCell)*(vvel(k-1,iCell) - vvel(k,iCell)) / &
                       (zm(k-1,iCell) - zm(k,iCell)) &
-                      + 2.88/(tau + 1.0E-10_RKIND)*grav*(alphaT(k,iCell)*wt(i1,k,iCell) - betaS(k,iCell)* &
-                      ws(i1,k,iCell)) - 3.84*eps(i1,k,iCell)/(tau + 1.0E-10_RKIND)
+                      + 2.88_RKIND/(tau + 1.0E-10_RKIND)*grav*(alphaT(k,iCell)*wt(i1,k,iCell) - betaS(k,iCell)* &
+                      ws(i1,k,iCell)) - 3.84_RKIND*eps(i1,k,iCell)/(tau + 1.0E-10_RKIND)
                  endif
 
 !     finally update all subplume fluxes
@@ -674,7 +678,7 @@ module ocn_adc_mixing_fused
                  ws_spsD(k,iCell) = -KhD(k,iCell)*Sz
 
                  if(k==2) then
-                    Cval = 3.96
+                    Cval = 3.96_RKIND
                  else
                     Cval = (0.19_RKIND+0.51_RKIND*lenspsU(k,iCell)/dzmid)
                  endif
@@ -685,12 +689,12 @@ module ocn_adc_mixing_fused
                    (ze(k-1,iCell) - ze(k,iCell)) - (KmU(k,iCell) +             &
                    KmU(k+1,iCell)) * (KspsU(i1,k,iCell) - KspsU(i1,k+1,iCell)) /     &
                    (ze(k,iCell) - ze(k+1,iCell))) / dzmid -                                 &
-                   Cval*KspsU(i1,k,iCell)**1.5_RKIND/(1.0E-15 + lenspsU(k,iCell)) +                     &
+                   Cval*KspsU(i1,k,iCell)**1.5_RKIND/(1.0E-15_RKIND + lenspsU(k,iCell)) +                     &
                    eps(i1,k,iCell) / (2.0_RKIND*(1.0_RKIND - areaFraction(k,iCell))) + KmU(k,iCell)* &
-                   (Uz**2.0 + Vz**2.0)
+                   (Uz**2.0_RKIND + Vz**2.0_RKIND)
 
                  if(k==2) then
-                    Cval = 3.96_RKIND
+                    Cval = 3.96_RKIND_RKIND
                  else
                     Cval = (0.19_RKIND+0.51_RKIND*lenspsD(k,iCell)/dz)
                  endif
@@ -703,7 +707,7 @@ module ocn_adc_mixing_fused
                    (ze(k,iCell) - ze(k+1,iCell))) / dz -                                 &
                    Cval*KspsD(i1,k,iCell)**1.5_RKIND /(1.0E-15_RKIND + lenspsD(k,iCell)) +                   &
                    eps(i1,k,iCell) / (2.0_RKIND*(areaFraction(k,iCell))) + &
-                   KmD(k,iCell)*(Uz**2.0 + Vz**2.0)
+                   KmD(k,iCell)*(Uz**2.0_RKIND + Vz**2.0_RKIND)
 
               enddo           ! nVertLevels
            enddo                ! nCells
@@ -790,10 +794,10 @@ module ocn_adc_mixing_fused
 !     Amrapalli: 16.6 here can be tuned if needed, would show up in u2 and v2 primarily
 !     also in KEspsU/D
                     KE = 0.5_RKIND*(u2(i2,k,iCell) + v2(i2,k,iCell) + w2(i2,k,iCell))
-                    length(k,iCell) = KE**1.5 / (c_epsilon * eps(i2,k,iCell))
+                    length(k,iCell) = KE**1.5_RKIND / (c_epsilon * eps(i2,k,iCell))
                  else
                     KE = 0.5_RKIND*(u2(i2,k,iCell) + v2(i2,k,iCell) + w2(i2,k,iCell))
-                    eps(:,k,iCell) = KE**1.5 / (c_epsilon * length(k,iCell))
+                    eps(:,k,iCell) = KE**1.5_RKIND / (c_epsilon * length(k,iCell))
                  endif
                  KspsU(i2,k,iCell) = max(epsilon,KspsU(i1,k,iCell) + dt_small*(Cw3 * &
                    KspsUtend(i3_f,k,iCell) + Cw2 * KspsUtend(i2_f,k,iCell) + Cw1 *    &
@@ -808,11 +812,11 @@ module ocn_adc_mixing_fused
 !     update the third order w3 and mean fields
            do iCell = 1,nCells
               do k=1,nVertLevels
-                 w3check = (w2(i2,k,iCell) + w2(i2,k+1,iCell))**1.5
-                 if(w3check < 3e-14_RKIND) w3check = 1.0
+                 w3check = (w2(i2,k,iCell) + w2(i2,k+1,iCell))**1.5_RKIND
+                 if(w3check < 3e-14_RKIND) w3check = 1.0_RKIND
                  w3(i2,k,iCell) = max(-w3check,min((w3(i1,k,iCell) + dt_small*(Cw3 * w3tend(i3_f,k,iCell) + &
                    Cw2 * w3tend(i2_f,k,iCell) + Cw1 * w3tend(i1_f,k,iCell))) / &
-                   (1.0_RKIND + 0.0*dt_small*tauw3(k,iCell)),w3check))
+                   (1.0_RKIND + 0.0_RKIND*dt_small*tauw3(k,iCell)),w3check))
 
 
                  if(abs(w3(i2,k,iCell)) > 1.0_RKIND) then

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -223,16 +223,16 @@ module ocn_adc_mixing_fused
               wumd(1,iCell) = 0.0_RKIND
               areaFraction(1,iCell) = 0.5_RKIND
               Mc(1,iCell) = 0.0_RKIND
-              w2t(1,iCell) = 0.0_RKIND !-0.3_RKIND*wstar * wtsfc(iCell)
-              w2s(1,iCell) = 0.0_RKIND !0.3_RKIND*wstar * wssfc(iCell)
+              w2t(1,iCell) = -0.3_RKIND*wstar * wtsfc(iCell)
+              w2s(1,iCell) = 0.3_RKIND*wstar * wssfc(iCell)
 
               sfcFrictionVelocitySquared = uwsfc(iCell) + vwsfc(iCell)
               frictionVelocity = sqrt(sfcFrictionVelocitySquared + config_adc_bc_wstar * wstar * wstar)
-!              frictionVelocity = max( config_adc_frictionVelocityMin, frictionVelocity )
+              frictionVelocity = max( config_adc_frictionVelocityMin*MtoCM, frictionVelocity )
               do k=1,3
                  u2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
                  v2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
-                 w2(k,1,iCell) = 0.0_RKIND !config_adc_bc_const_wp2*frictionVelocity**2.0_RKIND
+                 w2(k,1,iCell) = config_adc_bc_const_wp2*frictionVelocity**2.0_RKIND
                  uw(k,1,iCell) = -uwsfc(iCell)
                  vw(k,1,iCell) = -vwsfc(iCell)
                  wt(k,1,iCell) = wtsfc(iCell)

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -447,6 +447,11 @@ module ocn_adc_mixing_fused
                       - w3(i1,k+1,iCell)) / (zm(k-1,iCell) - zm(k+1,iCell))**2.0_RKIND
                  endif
 
+                 if (config_adc_truncate_tend) then
+                    w3tend(i3_f,k,iCell) = FLOAT (INT(w3tend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+
 !     now get all the downgradient TOMs
                  KE = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell))
                  KEp1 = 0.5_RKIND*(u2(i1,k+1,iCell) + v2(i1,k+1,iCell) + w2(i1,k+1,iCell))
@@ -503,7 +508,12 @@ module ocn_adc_mixing_fused
                    Mc(k,iCell)*(Swumd(k-1,iCell) + Swumd(k,iCell))
 
                  w2tend(i3_f,k,iCell) = w2tend1(k,iCell) + w2tend2(k,iCell) + &
-                 w2tend3(k,iCell) + w2tend4(k,iCell) + w2tend5(k,iCell) + w2tend6(k,iCell)
+                   w2tend3(k,iCell) + w2tend4(k,iCell) + w2tend5(k,iCell) + w2tend6(k,iCell)
+
+                 if (config_adc_truncate_tend) then
+                    w2tend(i3_f,k,iCell) = FLOAT (INT(w2tend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
 
                  wttend1(k,iCell) = -1.0_RKIND*(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
                    wumd(k,iCell)*tumd(k,iCell)
@@ -531,6 +541,11 @@ module ocn_adc_mixing_fused
                  wttend(i3_f,k,iCell) = wttend1(k,iCell) + wttend2(k,iCell) +        &
                    wttend3(k,iCell) + wttend4(k,iCell) + wttend5(k,iCell) + wttend6(k,iCell)
 
+                 if (config_adc_truncate_tend) then
+                    wttend(i3_f,k,iCell) = FLOAT (INT(wttend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+
                  wstend1(k,iCell) = -(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
                    wumd(k,iCell)*sumd(k,iCell)
                  wstend2(k,iCell) = ((1.0_RKIND - 2.0_RKIND*areaFraction(k-1,iCell))* &
@@ -555,6 +570,11 @@ module ocn_adc_mixing_fused
                  wstend(i3_f,k,iCell) = wstend1(k,iCell) + wstend2(k,iCell) + &
                    wstend3(k,iCell) + wstend4(k,iCell) + wstend5(k,iCell) + wstend6(k,iCell)
 
+                 if (config_adc_truncate_tend) then
+                    wstend(i3_f,k,iCell) = FLOAT (INT(wstend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+
                  uwtend1(k,iCell) = -(uw2(k-1,iCell) - uw2(k,iCell)) / dzmid
                  uwtend2(k,iCell) = 0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
                    (alpha_1 - alpha_2)*u2(i1,k,iCell) + (alpha_1 +  &
@@ -570,6 +590,11 @@ module ocn_adc_mixing_fused
                  uwtend(i3_f,k,iCell) = uwtend1(k,iCell) + uwtend2(k,iCell) + &
                    uwtend3(k,iCell) + uwtend4(k,iCell) + uwtend5(k,iCell)
 
+                 if (config_adc_truncate_tend) then
+                    uwtend(i3_f,k,iCell) = FLOAT (INT(uwtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+
                  vwtend(i3_f,k,iCell) = (-(vw2(k-1,iCell) - vw2(k,iCell)) / dzmid  &
                    + 0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
                    (alpha_1 - alpha_2)*v2(i1,k,iCell) + (alpha_1 +   &
@@ -579,11 +604,21 @@ module ocn_adc_mixing_fused
                    tauVel(k,iCell)*vw(i1,k,iCell) + kappa_FL*(vw(i1,k-1,iCell) &
                    - vw(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
+                 if (config_adc_truncate_tend) then
+                    vwtend(i3_f,k,iCell) = FLOAT (INT(vwtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+
                  uvtend(i3_f,k,iCell) = (-(uvw(k-1,iCell) - uvw(k,iCell)) / dz - &
                    (1.0_RKIND - 0.5_RKIND*(alpha_1+alpha_2))*(uw(i1,k,iCell)*Vz &
                    + vw(i1,k,iCell)*Uz)) - tauVel(k,iCell)*uv(i1,k,iCell) +           &
                    kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) /       &
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
+
+                 if (config_adc_truncate_tend) then
+                    uvtend(i3_f,k,iCell) = FLOAT (INT(uvtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
 
                  u2tend1(k,iCell) = -(u2w(k-1,iCell) - u2w(k,iCell)) / dzmid
                  u2tend2(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2 &
@@ -597,6 +632,11 @@ module ocn_adc_mixing_fused
                  u2tend(i3_f,k,iCell) = u2tend1(k,iCell) + u2tend2(k,iCell) + &
                    u2tend3(k,iCell) + u2tend4(k,iCell) + u2tend5(k,iCell) + u2tend6(k,iCell)
 
+                 if (config_adc_truncate_tend) then
+                    u2tend(i3_f,k,iCell) = FLOAT (INT(u2tend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+                
                  v2tend1(k,iCell) = -(v2w(k-1,iCell) - v2w(k,iCell)) / dzmid
                  v2tend2(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2 &
                    - 2.0_RKIND)*vw(i1,k,iCell)*Vz
@@ -609,21 +649,46 @@ module ocn_adc_mixing_fused
                  v2tend(i3_f,k,iCell) = v2tend1(k,iCell) + v2tend2(k,iCell) + &
                    v2tend3(k,iCell) + v2tend4(k,iCell) + v2tend5(k,iCell) + v2tend6(k,iCell)
 
+                 if (config_adc_truncate_tend) then
+                    v2tend(i3_f,k,iCell) = FLOAT (INT(v2tend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+
                  uttend(i3_f,k,iCell) = (-(uwt(k-1,iCell) - uwt(k,iCell))/dz -  &
                    uw(i1,k,iCell)*Tz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
                    alpha_tracer2))*wt(i1,k,iCell)*Uz) - ut(i1,k,iCell)*tau_tracer(k,iCell)
+
+                 if (config_adc_truncate_tend) then
+                    uttend(i3_f,k,iCell) = FLOAT (INT(uttend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
 
                  vttend(i3_f,k,iCell) = (-(vwt(k-1,iCell) - vwt(k,iCell))/dz -  &
                    vw(i1,k,iCell)*Tz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
                    alpha_tracer2))*wt(i1,k,iCell)*Vz) - vt(i1,k,iCell)*tau_tracer(k,iCell)
 
+                 if (config_adc_truncate_tend) then
+                    vttend(i3_f,k,iCell) = FLOAT (INT(vttend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+
                  ustend(i3_f,k,iCell) = (-(uws(k-1,iCell) - uws(k,iCell))/dz -  &
                    uw(i1,k,iCell)*Sz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
                    alpha_tracer2))*ws(i1,k,iCell)*Uz) - us(i1,k,iCell)*tau_tracer(k,ICell)
-                   
+                 
+                 if (config_adc_truncate_tend) then
+                    ustend(i3_f,k,iCell) = FLOAT (INT(ustend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+
                  vstend(i3_f,k,iCell) = (-(vws(k-1,iCell) - vws(k,iCell))/dz -  &
                    vw(i1,k,iCell)*Sz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
                    alpha_tracer2))*ws(i1,k,iCell)*Vz) - vs(i1,k,iCell)*tau_tracer(k,iCell)
+
+                 if (config_adc_truncate_tend) then
+                    vstend(i3_f,k,iCell) = FLOAT (INT(vstend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
 
                  t2(i2,k,iCell) = tumd(k,iCell)**2.0_RKIND*areaFraction(k,iCell)*&
                    (1.0_RKIND-areaFraction(k,iCell))
@@ -693,6 +758,11 @@ module ocn_adc_mixing_fused
                    eps(i1,k,iCell) / (2.0_RKIND*(1.0_RKIND - areaFraction(k,iCell))) + KmU(k,iCell)* &
                    (Uz**2.0_RKIND + Vz**2.0_RKIND)
 
+                 if (config_adc_truncate_tend) then
+                    KspsUtend(i3_f,k,iCell) = FLOAT (INT(KspsUtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
+
                  if(k==2) then
                     Cval = 3.96_RKIND_RKIND
                  else
@@ -708,6 +778,11 @@ module ocn_adc_mixing_fused
                    Cval*KspsD(i1,k,iCell)**1.5_RKIND /(1.0E-15_RKIND + lenspsD(k,iCell)) +                   &
                    eps(i1,k,iCell) / (2.0_RKIND*(areaFraction(k,iCell))) + &
                    KmD(k,iCell)*(Uz**2.0_RKIND + Vz**2.0_RKIND)
+
+                 if (config_adc_truncate_tend) then
+                    KspsDtend(i3_f,k,iCell) = FLOAT (INT(KspsDtend(i3_f,k,iCell) * config_adc_decimals_to_keep &
+                      + 0.5_RKIND)) / config_adc_decimals_to_keep
+                 endif
 
               enddo           ! nVertLevels
            enddo                ! nCells

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -13,19 +13,8 @@ module ocn_adc_mixing_fused
 
   integer :: i1_f, i2_f, i3_f, i1, i2
   real(kind=RKIND) :: Cw1, Cw2, Cw3
-  real(kind=RKIND) :: MtoCM
 
   contains
-
-  subroutine CGS_convert
-
-    if (config_adc_convert_to_CGS) then
-       MtoCM = 1000.0_RKIND
-    else
-       MtoCM = 1.0_RKIND
-    endif
-
-  end subroutine CGS_convert
 
   subroutine get_array_pointers
 
@@ -73,8 +62,6 @@ module ocn_adc_mixing_fused
       real (kind=RKIND) :: sumv, sumv0
       real (kind=RKIND), parameter :: refT = 15.0_RKIND, refS = 35.0_RKIND, minlen = 0.55_RKIND
 
-      call CGS_convert
-
 !     NOTE: will need to convert to some form of displaced density in the mpas framework soon
 !     possibly go back to a more traditional length scale formulation
       do iCell = 1,nCells
@@ -101,7 +88,7 @@ module ocn_adc_mixing_fused
          enddo
 
          do k = 1,nVertLevels+1
-            Bedge(k) = gravity * MtoCM * (alphaEdge(k) * (tedge(k) - refT) - &
+            Bedge(k) = gravity * (alphaEdge(k) * (tedge(k) - refT) - &
               betaEdge(k)  * (sedge(k) - refS))
 
             sigav = areaFraction(k,iCell)
@@ -113,8 +100,8 @@ module ocn_adc_mixing_fused
             Sup = sedge(k) + sigav*sumdav
             Sdn = sedge(k) - (1.0_RKIND - sigav)*sumdav
             
-            Bupedge(k) = gravity * MtoCM * (alphaEdge(k) * (Tup - refT) - betaEdge(k) * (Sup - refS))
-            Bdnedge(k) = gravity * MtoCM * (alphaEdge(k) * (Tdn - refT) - betaEdge(k) * (Sdn - refS))
+            Bupedge(k) = gravity * (alphaEdge(k) * (Tup - refT) - betaEdge(k) * (Sup - refS))
+            Bdnedge(k) = gravity * (alphaEdge(k) * (Tdn - refT) - betaEdge(k) * (Sdn - refS))
          enddo
 
          do k = 2,nVertLevels
@@ -126,7 +113,7 @@ module ocn_adc_mixing_fused
             do while(sumv0 <= tke(k) .and. ij > 1)
                sumv = sumv0 + (BEdge(ij) - BupEdge(k)) * (ze(ij-1,iCell)-ze(ij,iCell))
                if (sumv > tke(k)) THEN
-                  lenup(k,iCell) = max(minlen*MtoCM, lenup(k,iCell) + &
+                  lenup(k,iCell) = max(minlen, lenup(k,iCell) + &
                     abs(ze(ij-1,iCell)-ze(ij,iCell))*(tke(k)-sumv0)/(sumv-sumv0))
                     exit
                else
@@ -144,7 +131,7 @@ module ocn_adc_mixing_fused
             do while(sumv0 <= tke(k) .and. ij < nVertLevels+1)
                sumv = sumv0 + (BdnEdge(k) - BEdge(ij)) * (ze(ij-1,iCell)-ze(ij,iCell))
                if (sumv > tke(k)) THEN
-                  lendn(k,iCell) = max(minlen*MtoCM, lendn(k,iCell) + &
+                  lendn(k,iCell) = max(minlen, lendn(k,iCell) + &
                     abs(ze(ij-1,iCell)-ze(ij,iCell))*(tke(k)-sumv0)/(sumv-sumv0))
                     exit
                else
@@ -159,8 +146,8 @@ module ocn_adc_mixing_fused
          enddo
       enddo
 
-      length(1,iCell) = 0.55_RKIND*MtoCM
-      length(nVertLevels+1,iCell) = 0.55_RKIND*MtoCM
+      length(1,iCell) = 0.55_RKIND
+      length(nVertLevels+1,iCell) = 0.55_RKIND
 
   end subroutine dissipation_lengths2
 
@@ -202,7 +189,6 @@ module ocn_adc_mixing_fused
       dt_small = config_adc_timestep
       niter = dt / dt_small
 
-      call CGS_convert
       call get_array_pointers
       call get_weights
 
@@ -211,7 +197,7 @@ module ocn_adc_mixing_fused
       do iIter=1,niter
 !     on further examination build_diagnostics array can live outside the iter loop
          do iCell=1,nCells
-            Q = grav*MtoCM*(alphaT(1,iCell)*wtsfc(iCell) - betaS(1,iCell)*wssfc(iCell))* &
+            Q = grav*(alphaT(1,iCell)*wtsfc(iCell) - betaS(1,iCell)*wssfc(iCell))* &
               boundaryLayerDepth(iCell)
               if(Q > 0) then
                  wstar = abs(Q)**(1.0_RKIND/3.0_RKIND)
@@ -228,7 +214,7 @@ module ocn_adc_mixing_fused
 
               sfcFrictionVelocitySquared = uwsfc(iCell) + vwsfc(iCell)
               frictionVelocity = sqrt(sfcFrictionVelocitySquared + config_adc_bc_wstar * wstar * wstar)
-              frictionVelocity = max( config_adc_frictionVelocityMin*MtoCM, frictionVelocity )
+              frictionVelocity = max( config_adc_frictionVelocityMin, frictionVelocity )
               do k=1,3
                  u2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
                  v2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
@@ -349,7 +335,7 @@ module ocn_adc_mixing_fused
                  tumd(k,iCell) = wt(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
                  sumd(k,iCell) = ws(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
 
-                 if(w2(i1,k,iCell) <= epsilon*MtoCM*MtoCM + 1.0e-9_RKIND) then
+                 if(w2(i1,k,iCell) <= epsilon + 1.0e-9_RKIND) then
                     tumd(k,iCell) = 0.0_RKIND
                     sumd(k,iCell) = 0.0_RKIND
                  endif
@@ -448,14 +434,14 @@ module ocn_adc_mixing_fused
 
                  w3tend4(k,iCell) = -3.0_RKIND*(1.0_RKIND - 2.0_RKIND*sigav)*Mcav*wumdav*Swumd(k,iCell) - &
                    tauw3(k,iCell)*w3(i1,k,iCell)
-                 w3tend5(k,iCell) = 3.0_RKIND*(1.0_RKIND - c11)*grav*MtoCM*(alphaT(k,iCell)*w2t(k,iCell) - &
+                 w3tend5(k,iCell) = 3.0_RKIND*(1.0_RKIND - c11)*grav*(alphaT(k,iCell)*w2t(k,iCell) - &
                    betaS(k,iCell)*w2s(k,iCell))
 
                  w3tend(i3_f,k,iCell) = w3tend1(k,iCell) + w3tend2(k,iCell) + w3tend3(k,iCell) + &
                    w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell)
 
-                 if(k>1 .and. k < nVertLevels .and. kappa_w3*MtoCM*MtoCM > 0.0_RKIND) then
-                    w3tend(i3_f,k,iCell) = w3tend(i3_f,k,iCell) + kappa_w3*MtoCM*MtoCM*(w3(i1,k-1,iCell) &
+                 if(k>1 .and. k < nVertLevels .and. kappa_w3 > 0.0_RKIND) then
+                    w3tend(i3_f,k,iCell) = w3tend(i3_f,k,iCell) + kappa_w3*(w3(i1,k-1,iCell) &
                       - w3(i1,k+1,iCell)) / (zm(k-1,iCell) - zm(k+1,iCell))**2.0_RKIND
                  endif
 
@@ -490,7 +476,7 @@ module ocn_adc_mixing_fused
               do k=2,nVertLevels
                  dzmid = (zm(k-1,iCell) - zm(k,iCell))
                  dz = ze(k-1,iCell) - ze(k,iCell)
-                 B = grav*MtoCM*(alphaT(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND - &
+                 B = grav*(alphaT(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND - &
                    areaFraction(k,iCell))*wumd(k,iCell)*tumd(k,iCell) -      &
                    betaS(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND -          &
                    areaFraction(k,iCell))*wumd(k,iCell)*sumd(k,iCell))
@@ -514,7 +500,7 @@ module ocn_adc_mixing_fused
                    (1.0_RKIND - 2.0_RKIND*areaFractionMid(k,iCell))*wumdMid(k,iCell)**2.0_RKIND) / dzmid
                  w2tend3(k,iCell) = tauvVel(k,iCell)*(u2(i1,k,iCell) + v2(i1,k,iCell))/3.0_RKIND
                  w2tend4(k,iCell) = (2.0_RKIND - 4.0_RKIND/3.0_RKIND*C_b)*Mc(k,iCell)* &
-                   (grav*MtoCM*alphaT(k,iCell)*tumd(k,iCell) - grav*MtoCM*betaS(k,iCell)*sumd(k,iCell))
+                   (grav*alphaT(k,iCell)*tumd(k,iCell) - grav*betaS(k,iCell)*sumd(k,iCell))
                  w2tend5(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 -            &
                    alpha_2)*(uw(i1,k,iCell)*Uz + vw(i1,k,iCell)*Vz) +         &
                    Mc(k,iCell)*(Swumd(k-1,iCell) + Swumd(k,iCell))
@@ -532,11 +518,11 @@ module ocn_adc_mixing_fused
                  wttend2(k,iCell) = -(w2t(k-1,iCell) - w2t(k,iCell)) / (zm(k-1,iCell) - zm(k,iCell)) - &
                    Mc(k,iCell)*wumd(k,iCell)*Tz*0.0_RKIND
                  wttend3(k,iCell) = (1.0_RKIND - C_b_tracer)*areaFraction(k,iCell)*  &
-                   (1.0_RKIND - areaFraction(k,iCell))*grav*MtoCM*(alphaT(k,iCell) &
+                   (1.0_RKIND - areaFraction(k,iCell))*grav*(alphaT(k,iCell) &
                    *tumd(k,iCell)**2.0_RKIND - betaS(k,iCell)*tumd(k,iCell)*sumd(k,iCell))
                  wttend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(ut(i1,k,iCell)*Uz + &
                    vt(i1,k,iCell)*Vz) - Mc(k,iCell)*wumd(k,iCell)*Tz
-                 wttend5(k,iCell) = kappa_FL*MtoCM*MtoCM*(wt(i1,k-1,iCell) -       &
+                 wttend5(k,iCell) = kappa_FL*(wt(i1,k-1,iCell) -       &
                    wt(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
                  wttend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
                    tumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
@@ -560,12 +546,12 @@ module ocn_adc_mixing_fused
                    wumd(k-1,iCell)*sumd(k-1,iCell)*Mc(k-1,iCell) - (1.0_RKIND - 2.0_RKIND* &
                    areaFraction(k+1,iCell))*wumd(k+1,iCell)*sumd(k+1,iCell)*Mc(k+1,iCell)) &
                    / (ze(k-1,iCell) - ze(k+1,iCell)) - Mc(k,iCell)*wumd(k,iCell)*Sz
-                 wstend3(k,iCell) = (1.0_RKIND - C_b_tracer)*grav*MtoCM*areaFraction(k,iCell)* &
+                 wstend3(k,iCell) = (1.0_RKIND - C_b_tracer)*grav*areaFraction(k,iCell)* &
                    (1.0_RKIND - areaFraction(k,iCell))*(alphaT(k,iCell) &
                    *tumd(k,iCell)*sumd(k,iCell) - betaS(k,iCell)*sumd(k,iCell)*sumd(k,iCell))
                  wstend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + &
                    vs(i1,k,iCell)*Vz)
-                 wstend5(k,iCell) = kappa_FL*MtoCM*MtoCM*(ws(i1,k-1,iCell) -       &
+                 wstend5(k,iCell) = kappa_FL*(ws(i1,k-1,iCell) -       &
                    ws(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
                  wstend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
                    sumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
@@ -589,10 +575,10 @@ module ocn_adc_mixing_fused
                    alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Uz
                  uwtend3(k,iCell) = 0.5_RKIND*(alpha_1 - alpha_2)*    &
                    uv(i1,k,iCell)*Vz
-                 uwtend4(k,iCell) = (1-C_b)*grav*MtoCM*(alphaT(k,iCell)*   &
+                 uwtend4(k,iCell) = (1-C_b)*grav*(alphaT(k,iCell)*   &
                    ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell))
                  uwtend5(k,iCell) = -tauVel(k,iCell)*uw(i1,k,iCell) + &
-                   kappa_FL*MtoCM*MtoCM*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
+                   kappa_FL*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  uwtend(i3_f,k,iCell) = uwtend1(k,iCell) + uwtend2(k,iCell) + &
@@ -607,9 +593,9 @@ module ocn_adc_mixing_fused
                    + 0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
                    (alpha_1 - alpha_2)*v2(i1,k,iCell) + (alpha_1 +   &
                    alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Vz + 0.5_RKIND*(alpha_1 &
-                   - alpha_2)*uv(i1,k,iCell)*Uz + (1-C_b)*grav*MtoCM*       &
+                   - alpha_2)*uv(i1,k,iCell)*Uz + (1-C_b)*grav*       &
                    (alphaT(k,iCell)*vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))) -            &
-                   tauVel(k,iCell)*vw(i1,k,iCell) + kappa_FL*MtoCM*MtoCM*(vw(i1,k-1,iCell) &
+                   tauVel(k,iCell)*vw(i1,k,iCell) + kappa_FL*(vw(i1,k-1,iCell) &
                    - vw(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  if (config_adc_truncate_tend) then
@@ -620,7 +606,7 @@ module ocn_adc_mixing_fused
                  uvtend(i3_f,k,iCell) = (-(uvw(k-1,iCell) - uvw(k,iCell)) / dz - &
                    (1.0_RKIND - 0.5_RKIND*(alpha_1+alpha_2))*(uw(i1,k,iCell)*Vz &
                    + vw(i1,k,iCell)*Uz)) - tauVel(k,iCell)*uv(i1,k,iCell) +           &
-                   kappa_VAR*MtoCM*MtoCM*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) /       &
+                   kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) /       &
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
                  if (config_adc_truncate_tend) then
@@ -727,7 +713,7 @@ module ocn_adc_mixing_fused
                       (zm(k-1,iCell) - zm(k,iCell)) &
                       - 2.88_RKIND/(tau + 1.0E-10_RKIND)*vw(i1,k,iCell)*(vvel(k-1,iCell) - vvel(k,iCell)) / &
                       (zm(k-1,iCell) - zm(k,iCell)) &
-                      + 2.88_RKIND/(tau + 1.0E-10_RKIND)*grav*MtoCM*(alphaT(k,iCell)*wt(i1,k,iCell) - betaS(k,iCell)* &
+                      + 2.88_RKIND/(tau + 1.0E-10_RKIND)*grav*(alphaT(k,iCell)*wt(i1,k,iCell) - betaS(k,iCell)* &
                       ws(i1,k,iCell)) - 3.84_RKIND*eps(i1,k,iCell)/(tau + 1.0E-10_RKIND)
                  endif
 
@@ -756,7 +742,7 @@ module ocn_adc_mixing_fused
                     Cval = (0.19_RKIND+0.51_RKIND*lenspsU(k,iCell)/dzmid)
                  endif
 
-                 KspsUtend(i3_f,k,iCell) = grav*MtoCM*(alphaT(k,iCell)*wt_spsU(k,iCell) - &
+                 KspsUtend(i3_f,k,iCell) = grav*(alphaT(k,iCell)*wt_spsU(k,iCell) - &
                    betaS(k,iCell)*ws_spsU(k,ICell)) + ((KmU(k-1,iCell) +                 &
                    KmU(k,iCell))*(KspsU(i1,k-1,iCell) - KspsU(i1,k,iCell)) /         &
                    (ze(k-1,iCell) - ze(k,iCell)) - (KmU(k,iCell) +             &
@@ -777,7 +763,7 @@ module ocn_adc_mixing_fused
                     Cval = (0.19_RKIND+0.51_RKIND*lenspsD(k,iCell)/dz)
                  endif
 
-                 KspsDtend(i3_f,k,iCell) = grav*MtoCM*(alphaT(k,iCell)*wt_spsD(k,iCell) - &
+                 KspsDtend(i3_f,k,iCell) = grav*(alphaT(k,iCell)*wt_spsD(k,iCell) - &
                    betaS(k,iCell)*ws_spsD(k,iCell)) + ((KmD(k-1,iCell) +                 &
                    KmD(k,iCell))*(KspsD(i1,k-1,iCell) - KspsD(i1,k,iCell)) /         &
                    (ze(k-1,iCell) - ze(k,iCell)) - (KmD(k,iCell) +             &
@@ -802,12 +788,12 @@ module ocn_adc_mixing_fused
                  w2(i2,k,iCell) = (w2(i1,k,iCell) + dt_small*(Cw3 * w2tend(i3_f,k,iCell)  &
                    + Cw2 * w2tend(i2_f,k,iCell) + Cw1 * w2tend(i1_f,k,iCell))) /           &
                    (1.0_RKIND + dt_small*tauvVel(k,iCell)*2.0_RKIND/3.0_RKIND)
-                 if(w2(i2,k,iCell) < epsilon*MtoCM*MtoCM) then
-                    w2cliptend(k,iCell) = epsilon*MtoCM*MtoCM - w2(i2,k,iCell)
-                    w2(i2,k,iCell) = epsilon*MtoCM*MtoCM
+                 if(w2(i2,k,iCell) < epsilon) then
+                    w2cliptend(k,iCell) = epsilon - w2(i2,k,iCell)
+                    w2(i2,k,iCell) = epsilon
                  endif
 
-                 if(abs(w2(i2,k,iCell)) > 1.0_RKIND*MtoCM*MtoCM) then
+                 if(abs(w2(i2,k,iCell)) > 1.0_RKIND) then
                     call mpas_log_write("ERROR: w2 out of range, w2 = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/w2(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
@@ -815,17 +801,17 @@ module ocn_adc_mixing_fused
                  u2(i2,k,iCell) = (u2(i1,k,iCell) + dt_small*(Cw3 * u2tend(i3_f,k,iCell) +  &
                    Cw2 * u2tend(i2_f,k,iCell) + Cw1 * u2tend(i1_f,k,iCell))) /          &
                    (1.0_RKIND + dt_small*tauVel(k,iCell)*2.0_RKIND/3.0_RKIND)
-                 if(u2(i2,k,iCell) < epsilon*MtoCM*MtoCM) then
-                    u2cliptend(k,iCell) = epsilon*MtoCM*MtoCM - u2(i2,k,iCell)
-                    u2(i2,k,iCell) = epsilon*MtoCM*MtoCM
+                 if(u2(i2,k,iCell) < epsilon) then
+                    u2cliptend(k,iCell) = epsilon - u2(i2,k,iCell)
+                    u2(i2,k,iCell) = epsilon
                  endif
 
                  v2(i2,k,iCell) = (v2(i1,k,iCell) + dt_small*(Cw3 * v2tend(i3_f,k,iCell) + &
                    Cw2 * v2tend(i1_f,k,iCell) + Cw1 * v2tend(i1_f,k,iCell))) /              &
                    (1.0_RKIND + dt_small*tauVel(k,iCell)*2.0_RKIND/3.0_RKIND)
-                 if(v2(i2,k,iCell) < epsilon*MtoCM*MtoCM) then
-                    v2cliptend(k,iCell) = epsilon*MtoCM*MtoCM - v2(i2,k,iCell)
-                    v2(i2,k,iCell) = epsilon*MtoCM*MtoCM
+                 if(v2(i2,k,iCell) < epsilon) then
+                    v2cliptend(k,iCell) = epsilon - v2(i2,k,iCell)
+                    v2(i2,k,iCell) = epsilon
                  endif
 
                  uw(i2,k,iCell) = uw(i1,k,iCell) + dt_small*(Cw3 * uwtend(i3_f,k,iCell) + &
@@ -848,22 +834,22 @@ module ocn_adc_mixing_fused
                  ws(i2,k,iCell) = (ws(i1,k,iCell) + dt_small*(Cw3 * wstend(i3_f,k,iCell) + &
                    Cw2 * wstend(i2_f,k,iCell) + Cw1 * wstend(i1_f,k,iCell))) /              &
                    (1.0_RKIND + dt_small*tau_tracer(k,iCell))
-                 if(abs(wt(i2,k,iCell)) > 1.0_RKIND*MtoCM) then
+                 if(abs(wt(i2,k,iCell)) > 1.0_RKIND) then
                     call mpas_log_write("ERROR: wt out of range, wt = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/wt(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
                  
-                 if(abs(ws(i2,k,iCell)) > 1.0_RKIND*MtoCM) then
+                 if(abs(ws(i2,k,iCell)) > 1.0_RKIND) then
                     call mpas_log_write("ERROR: ws out of range, ws = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/ws(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
                  
-                 if(abs(u2(i2,k,iCell)) > 1.0_RKIND*MtoCM*MtoCM) then
+                 if(abs(u2(i2,k,iCell)) > 1.0_RKIND) then
                     call mpas_log_write("ERROR: u2 out of range, u2 = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/u2(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
 
-                 if(abs(v2(i2,k,iCell)) > 1.0_RKIND*MtoCM*MtoCM) then
+                 if(abs(v2(i2,k,iCell)) > 1.0_RKIND) then
                     call mpas_log_write("ERROR: v2 out of range, v2 = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/v2(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif
@@ -882,10 +868,10 @@ module ocn_adc_mixing_fused
                     KE = 0.5_RKIND*(u2(i2,k,iCell) + v2(i2,k,iCell) + w2(i2,k,iCell))
                     eps(:,k,iCell) = KE**1.5_RKIND / (c_epsilon * length(k,iCell))
                  endif
-                 KspsU(i2,k,iCell) = max(epsilon*MtoCM*MtoCM,KspsU(i1,k,iCell) + dt_small*(Cw3 * &
+                 KspsU(i2,k,iCell) = max(epsilon,KspsU(i1,k,iCell) + dt_small*(Cw3 * &
                    KspsUtend(i3_f,k,iCell) + Cw2 * KspsUtend(i2_f,k,iCell) + Cw1 *    &
                    KspsUtend(i1_f,k,iCell)))
-                 KspsD(i2,k,iCell) = max(epsilon*MtoCM*MtoCM,KspsD(i1,k,iCell) + dt_small*(Cw3 * &
+                 KspsD(i2,k,iCell) = max(epsilon,KspsD(i1,k,iCell) + dt_small*(Cw3 * &
                    KspsDtend(i3_f,k,iCell) + Cw2 * KspsDtend(i2_f,k,iCell) + Cw1 *    &
                    KspsDtend(i1_f,k,iCell)))
 
@@ -896,13 +882,13 @@ module ocn_adc_mixing_fused
            do iCell = 1,nCells
               do k=1,nVertLevels
                  w3check = (w2(i2,k,iCell) + w2(i2,k+1,iCell))**1.5_RKIND
-                 if(w3check < 3e-14_RKIND*MtoCM*MtoCM*MtoCM) w3check = 1.0_RKIND*MtoCM*MtoCM*MtoCM
+                 if(w3check < 3e-14_RKIND) w3check = 1.0_RKIND
                  w3(i2,k,iCell) = max(-w3check,min((w3(i1,k,iCell) + dt_small*(Cw3 * w3tend(i3_f,k,iCell) + &
                    Cw2 * w3tend(i2_f,k,iCell) + Cw1 * w3tend(i1_f,k,iCell))) / &
                    (1.0_RKIND + 0.0_RKIND*dt_small*tauw3(k,iCell)),w3check))
 
 
-                 if(abs(w3(i2,k,iCell)) > 1.0_RKIND*MtoCM*MtoCM*MtoCM) then
+                 if(abs(w3(i2,k,iCell)) > 1.0_RKIND) then
                     call mpas_log_write("ERROR: w3 out of range, w3 = $r, location = $i, $i", &
                       MPAS_LOG_CRIT,realArgs=(/w3(i2,k,iCell)/),intArgs=(/k,iCell/))
                  endif

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -49,159 +49,107 @@ module ocn_adc_mixing_fused
 
   end subroutine get_weights
 
-  subroutine dissipation_lengthsTest(nCells,nVertLevels,boundaryLayerDepth)
-		integer,intent(in) :: nVertLevels, nCells
-    real,dimension(nCells), intent(in) :: boundaryLayerDepth
-    integer :: iCell, k, ij, i
-
-    real (kind=RKIND) :: distToSfc, distToMLD, tke, sumTop, sumBottom
-
-    lenup(:,:) = 0.55_RKIND
-    lendn(:,:) = 0.55_RKIND
-    length(:,:) = 0.55_RKIND
-
-    sumTop = 0.0_RKIND
-    sumBottom = 0.0_RKIND
-    do k = 1, nVertLevels
-      tke = sqrt(0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell)))
-      sumTop = sumTop + tke*abs(ze(k,iCell))
-      sumBottom = sumBottom + tke
-    enddo
-
-    k=1
-    do while (abs(ze(k,iCell)) < boundaryLayerDepth(iCell))
-       distToSfc = abs(ze(k,iCell))
-       distToMLD = boundaryLayerDepth(iCell) - abs(ze(k,iCell))
-       lenup(k,iCell) = max(0.55,0.4*distToSfc / (0.4*distToSfc + sumTop / sumBottom))
-       lendn(k,iCell) = max(0.55,0.4*distToMLD / (0.4*distToMLD + sumTop / sumBottom))
-       length(k,iCell) = 2.0*lenup(k,iCell)*lendn(k,iCell) / (lenup(k,iCell) + lendn(k,iCell))
-       k = k + 1
-    end do
-
-  end subroutine dissipation_lengthsTest
-
   subroutine dissipation_lengths2(nCells,nVertLevels,activeTracers,alphaT,betaS)
-		integer,intent(in) :: nVertLevels, nCells
-    real (kind=RKIND), dimension(2,nVertLevels,nCells), intent(in) :: activeTracers
-    real (kind=RKIND), dimension(nVertLevels,nCells), intent(in) :: alphaT, betaS
-    integer :: iCell, k, ij, i
+      integer,intent(in) :: nVertLevels, nCells
+      real (kind=RKIND), dimension(2,nVertLevels,nCells), intent(in) :: activeTracers
+      real (kind=RKIND), dimension(nVertLevels,nCells), intent(in) :: alphaT, betaS
+      integer :: iCell, k, ij, i
 
-    real (kind=RKIND), dimension(nVertLevels) :: B, Bup, Bdn
-    real (kind=RKIND), dimension(nVertLevels+1) :: tedge, sedge, KEsps, tke, BupEdge, BdnEdge, BEdge
-    real (kind=RKIND), dimension(nVertLevels+1) :: alphaEdge, betaEdge
-    real (kind=RKIND) :: sigav, tumdav, sumdav, Tup, Tdn, Sup, Sdn
-    real (kind=RKIND) :: sumv, sumv0
-    real (kind=RKIND), parameter :: refT = 15.0_RKIND, refS = 35.0_RKIND, minlen = 0.55_RKIND
+      real (kind=RKIND), dimension(nVertLevels) :: B, Bup, Bdn
+      real (kind=RKIND), dimension(nVertLevels+1) :: tedge, sedge, KEsps, tke, BupEdge, BdnEdge, BEdge
+      real (kind=RKIND), dimension(nVertLevels+1) :: alphaEdge, betaEdge
+      real (kind=RKIND) :: sigav, tumdav, sumdav, Tup, Tdn, Sup, Sdn
+      real (kind=RKIND) :: sumv, sumv0
+      real (kind=RKIND), parameter :: refT = 15.0_RKIND, refS = 35.0_RKIND, minlen = 0.55_RKIND
 
 
-    !NOTE: will need to convert to some form of displaced density in the mpas framework soon
-    !possibly go back to a more traditional length scale formulation
-    do iCell = 1,nCells
-       do k = 2,nVertLevels
-          tedge(k) = 0.5_RKIND*(activeTracers(1,k,iCell) + activeTracers(1,k-1,iCell))
-          sedge(k) = 0.5_RKIND*(activeTracers(2,k,iCell) + activeTracers(2,k-1,iCell))
-          alphaEdge(k) = 0.5_RKIND*(alphaT(k,iCell) + alphaT(k-1,iCell))
-          betaEdge(k) = 0.5_RKIND*(betaS(k,iCell) + betaS(k-1,iCell))
-       end do
+!     NOTE: will need to convert to some form of displaced density in the mpas framework soon
+!     possibly go back to a more traditional length scale formulation
+      do iCell = 1,nCells
+         do k = 2,nVertLevels
+            tedge(k) = 0.5_RKIND*(activeTracers(1,k,iCell) + activeTracers(1,k-1,iCell))
+            sedge(k) = 0.5_RKIND*(activeTracers(2,k,iCell) + activeTracers(2,k-1,iCell))
+            alphaEdge(k) = 0.5_RKIND*(alphaT(k,iCell) + alphaT(k-1,iCell))
+            betaEdge(k) = 0.5_RKIND*(betaS(k,iCell) + betaS(k-1,iCell))
+         end do
 
-       betaEdge(1) = betaEdge(2)
-       alphaEdge(1) = alphaEdge(2)
-       betaEdge(nVertLevels+1) = betaEdge(nVertLevels)
-       alphaEdge(nVertLevels+1) = alphaEdge(nVertLevels)
-       tedge(1) = tedge(2)
-       sedge(1) = sedge(2)
-       tedge(nVertLevels+1) = tedge(nVertLevels)
-       sedge(nVertLevels+1) = sedge(nVertLevels)
+         betaEdge(1) = betaEdge(2)
+         alphaEdge(1) = alphaEdge(2)
+         betaEdge(nVertLevels+1) = betaEdge(nVertLevels)
+         alphaEdge(nVertLevels+1) = alphaEdge(nVertLevels)
+         tedge(1) = tedge(2)
+         sedge(1) = sedge(2)
+         tedge(nVertLevels+1) = tedge(nVertLevels)
+         sedge(nVertLevels+1) = sedge(nVertLevels)
 
-       do k = 1,nVertLevels+1
-          KEsps(k) = areaFraction(k,iCell) * KspsD(i1,k,iCell) + &
-                     (1.0_RKIND - areaFraction(k,iCell)) * KspsU(i1,k,iCell)
-          tke(k) = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell)) ! + KEsps(k)
-       enddo
+         do k = 1,nVertLevels+1
+            KEsps(k) = areaFraction(k,iCell) * KspsD(i1,k,iCell) + &
+              (1.0_RKIND - areaFraction(k,iCell)) * KspsU(i1,k,iCell)
+            tke(k) = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell)) ! + KEsps(k)
+         enddo
 
-       do k = 1,nVertLevels+1
-          Bedge(k) = gravity * (alphaEdge(k) * (tedge(k) - refT) - &
-                            betaEdge(k)  * (sedge(k) - refS))
+         do k = 1,nVertLevels+1
+            Bedge(k) = gravity * (alphaEdge(k) * (tedge(k) - refT) - &
+              betaEdge(k)  * (sedge(k) - refS))
 
-!          sigav  = 0.5_RKIND * (areaFraction(k,iCell) + areaFraction(k+1,iCell))
-!          tumdav = 0.5_RKIND * (tumd(k,iCell) + tumd(k+1,iCell))
-!          sumdav = 0.5_RKIND * (sumd(k,iCell) + sumd(k+1,iCell))
+            sigav = areaFraction(k,iCell)
+            tumdav = tumd(k,iCell)
+            sumdav = sumd(k,iCell)
 
-          sigav = areaFraction(k,iCell)
-          tumdav = tumd(k,iCell)
-          sumdav = sumd(k,iCell)
+            Tup = tedge(k) + sigav*tumdav
+            Tdn = tedge(k) - (1.0_RKIND - sigav)*tumdav
+            Sup = sedge(k) + sigav*sumdav
+            Sdn = sedge(k) - (1.0_RKIND - sigav)*sumdav
+            
+            Bupedge(k) = gravity * (alphaEdge(k) * (Tup - refT) - betaEdge(k) * (Sup - refS))
+            Bdnedge(k) = gravity * (alphaEdge(k) * (Tdn - refT) - betaEdge(k) * (Sdn - refS))
+         enddo
+         do k = 2,nVertLevels
+!           updraft length scale
+            sumv  = 0.0_RKIND
+            sumv0 = 0.0_RKIND
+            ij=k
+            lenup(k,iCell) = 0.0_RKIND
+            do while(sumv0 <= tke(k) .and. ij > 1)
+               sumv = sumv0 + (BEdge(ij) - BupEdge(k)) * (ze(ij-1,iCell)-ze(ij,iCell))
+               if (sumv > tke(k)) THEN
+                  lenup(k,iCell) = max(minlen, &
+                    lenup(k,iCell) + &
+                    abs(ze(ij-1,iCell)-ze(ij,iCell))*(tke(k)-sumv0)/(sumv-sumv0))
+                    exit
+               else
+                  lenup(k,iCell) = lenup(k,iCell) + abs(ze(ij-1,iCell)-ze(ij,iCell))
+               endif
+               sumv0 = sumv
+               ij = ij - 1
+            end do
 
-          Tup = tedge(k) + sigav*tumdav
-          Tdn = tedge(k) - (1.0_RKIND - sigav)*tumdav
-          Sup = sedge(k) + sigav*sumdav
-          Sdn = sedge(k) - (1.0_RKIND - sigav)*sumdav
+!           downdraft length scale
+            sumv  = 0.0_RKIND
+            sumv0 = 0.0_RKIND
+            ij=k
+            lendn(k,iCell) = 0.0_RKIND
+            do while(sumv0 <= tke(k) .and. ij < nVertLevels+1)
+               sumv = sumv0 + (BdnEdge(k) - BEdge(ij)) * (ze(ij-1,iCell)-ze(ij,iCell))
+               if (sumv > tke(k)) THEN
+                  lendn(k,iCell) = max(minlen, &
+                    lendn(k,iCell) + &
+                    abs(ze(ij-1,iCell)-ze(ij,iCell))*(tke(k)-sumv0)/(sumv-sumv0))
+                    exit
+               else
+                  lendn(k,iCell) = lendn(k,iCell) + abs(ze(ij-1,iCell)-ze(ij,iCell))
+               endif
+               sumv0 = sumv
+               ij = ij + 1
+            end do
 
-          Bupedge(k) = gravity * (alphaEdge(k) * (Tup - refT) - betaEdge(k) * (Sup - refS))
-          Bdnedge(k) = gravity * (alphaEdge(k) * (Tdn - refT) - betaEdge(k) * (Sdn - refS))
+            length(k,iCell) = 2.0_RKIND * lenup(k,iCell) * lendn(k,iCell)  &
+              / (lenup(k,iCell) + lendn(k,iCell))
+         enddo
+      enddo
 
-!          if(k>1) THEN
-!             BupEdge(k) = 0.5_RKIND * (Bup(k-1) + Bup(k))
-!             BdnEdge(k) = 0.5_RKIND * (Bdn(k-1) + Bdn(k))
-!             BEdge(k)   = 0.5_RKIND * (B(k-1) + B(k))
-!          endif
-       enddo
-
-!       BdnEdge(nVertLevels+1) = BdnEdge(nVertLevels)
-!       BupEdge(nVertLevels+1) = BupEdge(nVertLevels)
-!       BEdge(nVertLevels+1)   = BEdge(nVertLevels)
-
-!       BdnEdge(1) = BdnEdge(2)
-!       BupEdge(1) = BupEdge(2)
-!       BEdge(1)   = BEdge(2)
-
-       do k = 2,nVertLevels
-          ! updraft length scale
-          sumv  = 0.0_RKIND
-          sumv0 = 0.0_RKIND
-          ij=k
-          lenup(k,iCell) = 0.0_RKIND
-          do while(sumv0 <= tke(k) .and. ij > 1)
-             sumv = sumv0 + (BEdge(ij) - BupEdge(k)) * (ze(ij-1,iCell)-ze(ij,iCell))
-             if (sumv > tke(k)) THEN
-                lenup(k,iCell) = max(minlen, &
-                                     lenup(k,iCell) + &
-                                     abs(ze(ij-1,iCell)-ze(ij,iCell))*(tke(k)-sumv0)/(sumv-sumv0))
-                exit
-             else
-                lenup(k,iCell) = lenup(k,iCell) + abs(ze(ij-1,iCell)-ze(ij,iCell))
-             endif
-             sumv0 = sumv
-             ij = ij - 1
-          end do
-
-          ! downdraft length scale
-          sumv  = 0.0_RKIND
-          sumv0 = 0.0_RKIND
-          ij=k
-          lendn(k,iCell) = 0.0_RKIND
-          do while(sumv0 <= tke(k) .and. ij < nVertLevels+1)
-             sumv = sumv0 + (BdnEdge(k) - BEdge(ij)) * (ze(ij-1,iCell)-ze(ij,iCell))
-             if (sumv > tke(k)) THEN
-                lendn(k,iCell) = max(minlen, &
-                                     lendn(k,iCell) + &
-                                     abs(ze(ij-1,iCell)-ze(ij,iCell))*(tke(k)-sumv0)/(sumv-sumv0))
-                exit
-             else
-                lendn(k,iCell) = lendn(k,iCell) + abs(ze(ij-1,iCell)-ze(ij,iCell))
-             endif
-             sumv0 = sumv
-             ij = ij + 1
-          end do
-
-          length(k,iCell) = 2.0_RKIND * lenup(k,iCell) * lendn(k,iCell)  &
-                            / (lenup(k,iCell) + lendn(k,iCell))
-          ! write(*,*) k, iCell, lenup(k,iCell), lendn(k,iCell)
-       enddo
-       ! write(*,*) '----'
-    enddo
-
-    length(1,iCell) = 0.55_RKIND
-    length(nVertLevels+1,iCell) = 0.55_RKIND
+      length(1,iCell) = 0.55_RKIND
+      length(nVertLevels+1,iCell) = 0.55_RKIND
 
   end subroutine dissipation_lengths2
 
@@ -249,696 +197,662 @@ module ocn_adc_mixing_fused
       stopflag = .false.
 
       do iIter=1,niter
-      !on further examination build_diagnostics array can live outside the iter loop
-      do iCell=1,nCells
-        Q = grav*(alphaT(1,iCell)*wtsfc(iCell) - betaS(1,iCell)*wssfc(iCell))* &
-            boundaryLayerDepth(iCell)
-        if(Q > 0) then
-          wstar = abs(Q)**(1.0/3.0)
-        else
-          wstar = 0.0
-        endif
-
-        tumd(1,iCell) = 0.0_RKIND
-        wumd(1,iCell) = 0.0_RKIND
-        areaFraction(1,iCell) = 0.5_RKIND
-        Mc(1,iCell) = 0.0_RKIND
-        w2t(1,iCell) = -0.3_RKIND*wstar * wtsfc(iCell)
-        w2s(1,iCell) = 0.3_RKIND*wstar * wssfc(iCell)
-
-        sfcFrictionVelocitySquared = uwsfc(iCell) + vwsfc(iCell)
-        frictionVelocity = sqrt(sfcFrictionVelocitySquared + config_adc_bc_wstar * wstar * wstar)
-        frictionVelocity = max( config_adc_frictionVelocityMin, frictionVelocity )
-        do k=1,2
-          u2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0
-          v2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0
-          w2(k,1,iCell) = config_adc_bc_const_wp2*frictionVelocity**2.0
-          uw(k,1,iCell) = -uwsfc(iCell)
-          vw(k,1,iCell) = -vwsfc(iCell)
-          wt(k,1,iCell) = wtsfc(iCell)
-          ws(k,1,iCell) = wssfc(iCell)
-          KE = 0.5*(u2(i1,1,iCell) + v2(i1,1,iCell))
-          eps(k,1,iCell) = KE**1.5/(0.5*(ze(1,iCell) - ze(2,iCell) + 1.0E-10_RKIND))
-        enddo
-      enddo
-
-      ! compute the splat effect, adds w3tend and w2tend
-      if(config_adc_use_splat_parameterization) then
-         ! do k=1 separately for performance reasons, for k=1 we use one sided derivatives
-         ! note that the splat_factor forces the term to be smaller than factor * dt
-         k=1
+!     on further examination build_diagnostics array can live outside the iter loop
          do iCell=1,nCells
-            d_sqrt_wp2_dz = (sqrt(w2(i1,1,iCell)) - sqrt(0.5_RKIND*(w2(i1,1,iCell)+ &
-                              w2(i1,2,iCell)))) / (ze(1,iCell) - zm(1,iCell))
-            tau_sfc = length(1,iCell) / sqrt(0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell)))
-            w2tend6(1,iCell) = min(max(-config_adc_splat_tend_max, -w2(i1,1,iCell)*      &
-                                config_adc_splat_wp2_val*tau_sfc*d_sqrt_wp2_dz**2),      &
-                                config_adc_splat_tend_max)
-            tau_sfc = 0.5_RKIND*(length(1,iCell) + length(2,iCell)) / sqrt(0.5_RKIND*( &
-                      0.5_RKIND*(u2(i1,1,iCell) + u2(i1,2,iCell)) + 0.5_RKIND*(          &
-                      v2(i1,1,iCell) + v2(i1,2,iCell)) + 0.5_RKIND*(w2(i1,1,iCell) +      &
-                      w2(i1,2,iCell))))
-            d_sqrt_wp2_dz = (sqrt(w2(i1,1,iCell)) - sqrt(w2(i1,2,iCell))) / &
-                              (ze(1,iCell) - ze(2,iCell))
-            w3tend6(1,iCell) = min(max(-config_adc_splat_tend_max, -w3(i1,1,iCell)*      &
-                                   config_adc_splat_wp2_val*tau_sfc*d_sqrt_wp2_dz**2),   &
-                                   config_adc_splat_tend_max)
-         end do
+            Q = grav*(alphaT(1,iCell)*wtsfc(iCell) - betaS(1,iCell)*wssfc(iCell))* &
+              boundaryLayerDepth(iCell)
+              if(Q > 0) then
+                 wstar = abs(Q)**(1.0/3.0)
+              else
+                 wstar = 0.0
+              endif
 
-         do iCell=1,nCells
-            do k=2,nVertLevels
-               d_sqrt_wp2_dz = (sqrt(w2(i1,k-1,iCell)) - sqrt(w2(i1,k+1,iCell))) / &
-                                (ze(k-1,iCell) - ze(k+1,iCell))
-               tau_sfc = length(k,iCell) / sqrt(0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + &
-                                w2(i1,k,iCell)))
-               w2tend6(k,iCell) = min(max(-config_adc_splat_tend_max, -w2(i1,k,iCell)*      &
-                                   config_adc_splat_wp2_val*tau_sfc*d_sqrt_wp2_dz**2),      &
-                                   config_adc_splat_tend_max)
-               tau_sfc = 0.5_RKIND*(length(k,iCell) + length(k+1,iCell)) / sqrt(0.5_RKIND*( &
-                      0.5_RKIND*(u2(i1,k,iCell) + u2(i1,k+1,iCell)) + 0.5_RKIND*(          &
+              tumd(1,iCell) = 0.0_RKIND
+              wumd(1,iCell) = 0.0_RKIND
+              areaFraction(1,iCell) = 0.5_RKIND
+              Mc(1,iCell) = 0.0_RKIND
+              w2t(1,iCell) = -0.3_RKIND*wstar * wtsfc(iCell)
+              w2s(1,iCell) = 0.3_RKIND*wstar * wssfc(iCell)
+
+              sfcFrictionVelocitySquared = uwsfc(iCell) + vwsfc(iCell)
+              frictionVelocity = sqrt(sfcFrictionVelocitySquared + config_adc_bc_wstar * wstar * wstar)
+              frictionVelocity = max( config_adc_frictionVelocityMin, frictionVelocity )
+              do k=1,3
+                 u2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0
+                 v2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0
+                 w2(k,1,iCell) = config_adc_bc_const_wp2*frictionVelocity**2.0
+                 uw(k,1,iCell) = -uwsfc(iCell)
+                 vw(k,1,iCell) = -vwsfc(iCell)
+                 wt(k,1,iCell) = wtsfc(iCell)
+                 ws(k,1,iCell) = wssfc(iCell)
+                 KE = 0.5*(u2(i1,1,iCell) + v2(i1,1,iCell))
+                 eps(k,1,iCell) = KE**1.5/(0.5*(ze(1,iCell) - ze(2,iCell) + 1.0E-10_RKIND))
+              enddo
+           enddo
+
+!     compute the splat effect, adds w3tend and w2tend
+           if(config_adc_use_splat_parameterization) then
+!     do k=1 separately for performance reasons, for k=1 we use one sided derivatives
+!     note that the splat_factor forces the term to be smaller than factor * dt
+              k=1
+              do iCell=1,nCells
+                 d_sqrt_wp2_dz = (sqrt(w2(i1,1,iCell)) - sqrt(0.5_RKIND*(w2(i1,1,iCell)+ &
+                   w2(i1,2,iCell)))) / (ze(1,iCell) - zm(1,iCell))
+                 tau_sfc = length(1,iCell) / sqrt(0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell)))
+                 w2tend6(1,iCell) = min(max(-config_adc_splat_tend_max, -w2(i1,1,iCell)*      &
+                   config_adc_splat_wp2_val*tau_sfc*d_sqrt_wp2_dz**2),      &
+                   config_adc_splat_tend_max)
+                 tau_sfc = 0.5_RKIND*(length(1,iCell) + length(2,iCell)) / sqrt(0.5_RKIND* &
+                   (0.5_RKIND*(u2(i1,1,iCell) + u2(i1,2,iCell)) + 0.5_RKIND*(          &
+                   v2(i1,1,iCell) + v2(i1,2,iCell)) + 0.5_RKIND*(w2(i1,1,iCell) +      &
+                   w2(i1,2,iCell))))
+                 d_sqrt_wp2_dz = (sqrt(w2(i1,1,iCell)) - sqrt(w2(i1,2,iCell))) / &
+                   (ze(1,iCell) - ze(2,iCell))
+                 w3tend6(1,iCell) = min(max(-config_adc_splat_tend_max, -w3(i1,1,iCell)*      &
+                   config_adc_splat_wp2_val*tau_sfc*d_sqrt_wp2_dz**2),   &
+                   config_adc_splat_tend_max)
+              end do
+
+              do iCell=1,nCells
+                 do k=2,nVertLevels
+                    d_sqrt_wp2_dz = (sqrt(w2(i1,k-1,iCell)) - sqrt(w2(i1,k+1,iCell))) / &
+                      (ze(k-1,iCell) - ze(k+1,iCell))
+                    tau_sfc = length(k,iCell) / sqrt(0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + &
+                      w2(i1,k,iCell)))
+                    w2tend6(k,iCell) = min(max(-config_adc_splat_tend_max, -w2(i1,k,iCell)*      &
+                      config_adc_splat_wp2_val*tau_sfc*d_sqrt_wp2_dz**2),      &
+                      config_adc_splat_tend_max)
+                    tau_sfc = 0.5_RKIND*(length(k,iCell) + length(k+1,iCell)) / sqrt(0.5_RKIND* &
+                      (0.5_RKIND*(u2(i1,k,iCell) + u2(i1,k+1,iCell)) + 0.5_RKIND*(          &
                       v2(i1,k,iCell) + v2(i1,k+1,iCell)) + 0.5_RKIND*(w2(i1,k,iCell) +      &
                       w2(i1,k+1,iCell))))
-               d_sqrt_wp2_dz = (sqrt(w2(i1,k,iCell)) - sqrt(w2(i1,k+1,iCell))) / &
-                              (ze(k,iCell) - ze(k+1,iCell))
-               w3tend6(1,iCell) = min(max(-config_adc_splat_tend_max, -w3(i1,k,iCell)*         &
-                                           config_adc_splat_wp2_val*tau_sfc*d_sqrt_wp2_dz**2), &
-                                           config_adc_splat_tend_max)
-            end do
-         end do
-
-         do iCell=1,nCells
-            tp2 = 0.4_RKIND * config_adc_bc_const * (wt(i1,1,iCell) / frictionVelocity)**2
-            sp2 = 0.4_RKIND * config_adc_bc_const * (ws(i1,1,iCell) / frictionVelocity)**2
-            min_wp2_sfc_val = max(1.0E-10_RKIND, wt(i1,1,iCell)**2 / (tp2 * 0.99_RKIND**2 + 1.0E-15_RKIND), &
-                                    ws(i1,1,iCell)**2 / (sp2 * 0.99_RKIND**2 + 1.0E-15_RKIND))
-            tau_sfc = length(1,iCell) / sqrt(0.5_RKIND*(u2(i1,1,iCell) + v2(i1,1,iCell)))
-
-            if(w2(i1,1,iCell) + tau_sfc * w2tend6(1,iCell) < min_wps_sfc_val) then
-               wp2_splat_sfc_correction = -w2(i1,1,iCell) + min_wp2_sfc_val
-               w2(i1,1,iCell) = min_wp2_sfc_val
-            else
-               wp2_splat_sfc_correction = tau_sfc * w2tend6(1,iCell)
-               w2(i1,1,iCell) = w2(i1,1,iCell) + wp2_splat_sfc_correction
-            end if
-            u2(i1,1,iCell) = u2(i1,1,iCell) - 0.5_RKIND * wp2_splat_sfc_correction
-            v2(i1,1,iCell) = v2(i1,1,iCell) - 0.5_RKIND * wp2_splat_sfc_correction
-        end do
-
-        !build up splat tend for u2 and v2
-        do iCell=1,nCells
-           do k=2,nVertLevels
-              u2tend6(k,iCell) = -0.5_RKIND*w2tend6(k,iCell)
-              v2tend6(k,iCell) = -0.5_RKIND*w2tend6(k,iCell)
-           end do
-        end do
-     else
-        do iCell=1,nCells
-           do k=1,nVertLevels
-              w3tend6(k,iCell) = 0.0_RKIND
-              w2tend6(k,iCell) = 0.0_RKIND
-              u2tend6(k,iCell) = 0.0_RKIND
-              v2tend6(k,iCell) = 0.0_RKIND
-           end do
-        end do
-     end if ! end use splat correction
-
-
-      !Kernel 1 inlined versions of the base arrays, needed for later to make them collapsible
-         do iCell=1,nCells
-          do k=2,nVertLevels
-            w3av = 0.5_RKIND*(w3(i1,k-1,iCell) + w3(i1,k,iCell))
-
-            Sw = w3av / (w2(i1,k,iCell)**1.5_RKIND + 1.0E-15_RKIND)
-            lareaFraction = 0.5_RKIND + 0.5_RKIND*Sw / sqrt(4.0_RKIND + Sw**2)
-
-            if(lareaFraction < 0.01_RKIND) then
-            !  w3(i1,k-1,iCell) = -2.0_RKIND*(9.8*w2(i1,k,iCell)**1.5) - w3(i1,k,iCell)
-              lareaFraction = 0.01_RKIND
-            end if
-
-            if(lareaFraction > 0.99_RKIND) then
-            !  w3(i1,k-1,iCell) = 2.0_RKIND*(9.8*w2(i1,k,iCell)**1.5) - w3(i1,k,iCell)
-              lareaFraction = 0.99_RKIND
-            end if
-
-            areaFraction(k,iCell) = lareaFraction
-
-            wumd(k,iCell) = sqrt(w2(i1,k,iCell) / (areaFraction(k,iCell) * &
-               (1.0_RKIND - areaFraction(k,iCell))))
-            Mc(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - &
-               areaFraction(k,iCell)) * wumd(k,iCell)
-
-            tumd(k,iCell) = wt(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
-            sumd(k,iCell) = ws(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
-
-            if(w2(i1,k,iCell) <= epsilon + 1.0e-9) then
-              ! areaFraction(k,iCell) = 0.5_RKIND
-              ! wumd(k,iCell) = 0.0_RKIND
-               tumd(k,iCell) = 0.0_RKIND
-               sumd(k,iCell) = 0.0_RKIND
-               !Mc(k,iCell) = 0.0_RKIND
-              !w2(i1,k,iCell) = 0.0_RKIND
-            endif
-             !redo mid quantities
-            areaFractionMid(k-1,iCell) = 0.5_RKIND*(areaFraction(k-1,iCell) + areaFraction(k,iCell))
-            wumdMid(k-1,iCell) = 0.5_RKIND*(wumd(k-1,iCell) + wumd(k,iCell))
-            tumdMid(k-1,iCell) = 0.5_RKIND*(tumd(k-1,iCell) + tumd(k,iCell))
-            sumdMid(k-1,iCell) = 0.5_RKIND*(sumd(k-1,iCell) + sumd(k,iCell))
-            McMid(k-1,iCell) = 0.5_RKIND*(Mc(k-1,iCell) + Mc(k,iCell))
-       enddo
-        areaFractionMid(nVertLevels,iCell) = 0.5_RKIND
-        wumdMid(nVertLevels,iCell) = 0.0_RKIND
-        tumdMid(nVertLevels,iCell) = 0.0_RKIND
-        sumdMid(nVertLevels,iCell) = 0.0_RKIND
-        McMid(nVertLevels,iCell) = 0.0_RKIND
-      enddo
-
-        do iCell = 1,nCells
-          do k=2,nVertLevels
-            sigav = 0.5_RKIND*(areaFraction(k,iCell) + areaFraction(k+1,iCell))
-            tumdav = 0.5_RKIND*(tumd(k,iCell) + tumd(k+1,iCell))
-            sumdav = 0.5_RKIND*(sumd(k,iCell) + sumd(k+1,iCell))
-            wumdav = 0.5_RKIND*(wumd(k,iCell) + wumd(k+1,iCell))
-            sigav = areaFractionMid(k,iCell)
-            tumdav = tumdMid(k,iCell)
-            wumdav = wumdMid(k,iCell)
-            sumdav = sumdMid(k,iCell)
-            w2tTemp = -sigav*(1.0_RKIND - sigav)*(1.0_RKIND - 2.0_RKIND*sigav)*wumdav**2.0_RKIND*tumdav
-            w2tCheck = sigav*(1.0_RKIND - sigav)*sqrt(1.0_RKIND - 3.0_RKIND*sigav + 3.0_RKIND*sigav**2)* &
-              wumdav**2.0*tumdav
-            w2t(k,iCell) = w2tTemp !max(-w2tCheck, min(w2tTemp, w2tCheck))
-
-            w2sTemp = -sigav*(1.0_RKIND - sigav)*(1.0_RKIND - 2.0_RKIND*sigav)*wumdav**2.0_RKIND*sumdav
-            w2sCheck = sigav*(1.0_RKIND - sigav)*sqrt(1.0_RKIND - 3.0_RKIND*sigav + 3.0_RKIND*sigav**2)* &
-              wumdav**2.0*sumdav
-            w2s(k,iCell) = w2sTemp !max(-w2sCheck, min(w2sTemp, w2sCheck))
-
-            !also use this loop to reset the cliptends for the step
-            u2cliptend(k,iCell) = 0.0_RKIND
-            v2cliptend(k,iCell) = 0.0_RKIND
-            w2cliptend(k,iCell) = 0.0_RKIND
-          enddo
-        enddo
-          if(config_adc_use_old_length_scale)then
-					  call dissipation_lengths2(nCells,nVertLevels,activeTracers,alphaT,betaS)
- !           call dissipation_lengthsTest(nCells,nVertLevels,boundaryLayerDepth)
-          endif
-        do iCell = 1,nCells
-           do k=1,nVertLevels
-              !change length scale to lenup and lendown
-              Entrainment(k,iCell) = Cww_E*areaFraction(k,iCell)*(1.0_RKIND- &
-                areaFraction(k,iCell))*Mc(k,iCell) / ( lenup(k,iCell) + 1.0E-15_RKIND )
-              Detrainment(k,iCell) = Cww_D*areaFraction(k,iCell)*(1.0_RKIND- &
-                areaFraction(k,iCell))*Mc(k,iCell) / ( lendn(k,iCell) +1.0E-15_RKIND )
-            enddo
-          enddo
-
-        !This cell loop computes w3Tend and TOMs for later tendencies.  Should be okay to collapse loops here
-        do iCell = 1,nCells
-            do k=1,nVertLevels
-              Eav = 0.5*(Entrainment(k+1,iCell) + Entrainment(k,iCell))
-              Dav = 0.5*(Detrainment(k+1,iCell) + Detrainment(k,iCell))
-              u2av = 0.5*(u2(i1,k,iCell) + u2(i1,k+1,iCell))
-              v2av = 0.5*(v2(i1,k,iCell) + v2(i1,k+1,iCell))
-              w2av = 0.5*(w2(i1,k,iCell) + w2(i1,k+1,iCell))
-
-              sigav = 0.5*(areaFraction(k,iCell) + areaFraction(k+1,iCell))
-              wumdav = 0.5*(wumd(k,iCell) + wumd(k+1,iCell))
-              tumdav = 0.5*(tumd(k,iCell) + tumd(k+1,iCell))
-              sumdav = 0.5*(sumd(k,iCell) + sumd(k+1,iCell))
-              Mcav = 0.5*(Mc(k,iCell) + Mc(k+1,iCell))
-              lenav = 0.5*(length(k,iCell) + length(k+1,iCell))
-              KE = sqrt(0.5_RKIND*(u2av+v2av+w2av))
-
-              dz = ze(k,iCell) - ze(k+1,iCell)
-              !KE = sqrt(areaFraction(k,iCell)*KspsUav + (1.0 - areaFraction(k,iCell))*KspsDav)
-              Swumd(k,iCell) = - 2.0/3.0*(1.0_RKIND/sigav*(areaFraction(k,iCell)*KspsD(i1,k,iCell) - &
-                areaFraction(k+1,iCell)*KspsD(i1,k+1,iCell)) / dz - 1.0_RKIND / (1.0_RKIND - &
-                sigav)*((1.0_RKIND - areaFraction(k,iCell))*KspsU(i1,k,iCell) - (1.0_RKIND - &
-                areaFraction(k+1,iCell))*KspsU(i1,k+1,iCell)) / dz)
-
-              tauw3(k,iCell) = C_mom_w3*KE / (1.0E-15_RKIND + sqrt(2.0_RKIND)*lenAv)
-
-              wumdav = wumdMid(k,ICell)
-              sigav = areaFractionMid(k,iCell)
-              Mcav = McMid(k,iCell)
-
-              w3tend1(k,iCell) = -wumdav**3.0*(Eav*(3.0*sigav - 2.0) + Dav*(3.0*sigav - 1.0))
-!              w3tend2(k,iCell) = -wumdav**3.0*(6.0*sigav**2.0 - 6.0*sigav + 1)*             &
-!                    (areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))*  &
-!                    wumd(k,iCell) - areaFraction(k+1,iCell)*(1.0_RKIND - &
-!                    areaFraction(k+1,iCell))*wumd(k+1,iCell))/dz
-!              w3tend3(k,iCell) = -1.5_RKIND*sigav*(1.0_RKIND - sigav)*(1.0_RKIND - 2.0_RKIND*sigav)* &
-!                    wumdav**2.0_RKIND*((1.0_RKIND - 2.0_RKIND*areaFraction(k,iCell))*      &
-!                    wumd(k,iCell)**2.0_RKIND - (1.0_RKIND -                                &
-!                    2.0_RKIND*areaFraction(k+1,iCell))*wumd(k+1,iCell)**2.0_RKIND) / dz
-              !Revert to QNA for the w4 term and combine with transport term, zeroing out w3tend2 as its unneeded
-
-              Swk   =  -(1.0_RKIND-2.0_RKIND*sigav)/(sigav*(1.0_RKIND-sigav))**0.5
-              w3tend2(k,iCell) = -((3.0_RKIND + Swk**2.0)*(w2(i1,k,iCell)**2.0) - &
-                                   (3.0_RKIND + Swk**2.0)*(w2(i1,k+1,iCell)**2.0) ) / dz
-              w3tend3(k,iCell) = 1.5_RKIND*(w2(i1,k,iCell)**2.0 - w2(i1,k+1,iCell)**2.0) / dz
-
-!              w3tend2(k,iCell) = 0.0_RKIND
-!              w3tend3(k,iCell) = -1.5_RKIND*(w2(i1,k,iCell)**2.0 - w2(i1,k+1,iCell)**2.0) / dz
-              w3tend4(k,iCell) = -3.0_RKIND*(1.0_RKIND - 2.0_RKIND*sigav)*Mcav*wumdav*Swumd(k,iCell) - &
-                    tauw3(k,iCell)*w3(i1,k,iCell)
-              w3tend5(k,iCell) = 3.0_RKIND*(1.0_RKIND - c11)*grav*(alphaT(k,iCell)*w2t(k,iCell) - &
-                    betaS(k,iCell)*w2s(k,iCell))
-
-              w3tend(i3_f,k,iCell) = w3tend1(k,iCell) + w3tend2(k,iCell) + w3tend3(k,iCell) + &
-                w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell)
-
-              if(k>1 .and. k < nVertLevels .and. kappa_w3 > 0.0) then
-                 w3tend(i3_f,k,iCell) = w3tend(i3_f,k,iCell) + kappa_w3*(w3(i1,k-1,iCell) &
-                    - w3(i1,k+1,iCell)) / (zm(k-1,iCell) - zm(k+1,iCell))**2.0
-              endif
-
-            ! now get all the downgradient TOMs
-              KE = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell))
-              KEp1 = 0.5_RKIND*(u2(i1,k+1,iCell) + v2(i1,k+1,iCell) + w2(i1,k+1,iCell))
-              lenav = 0.5_RKIND*(length(k,iCell) + length(k+1,iCell))
-              diff = C_mom * sqrt(0.5_RKIND*(KE + KEp1)) * lenav
-              dz = ze(k,iCell) - ze(k+1,iCell)
-              uw2(k,iCell) = -diff*(uw(i1,k,iCell) - uw(i1,k+1,iCell)) / dz
-              vw2(k,iCell) = -diff*(vw(i1,k,iCell) - vw(i1,k+1,iCell)) / dz
-              u2w(k,iCell) = -diff*(u2(i1,k,iCell) - u2(i1,k+1,iCell)) / dz
-              v2w(k,iCell) = -diff*(v2(i1,k,iCell) - v2(i1,k+1,iCell)) / dz
-              uvw(k,iCell) = -diff*(uv(i1,k,iCell) - uv(i1,k+1,iCell)) / dz
-
-              diff = C_therm*sqrt(0.5*(KE + KEp1)) * lenav
-              uwt(k,iCell) = -diff*(ut(i1,k,iCell) - ut(i1,k+1,iCell)) / dz
-              vwt(k,iCell) = -diff*(vt(i1,k,iCell) - vt(i1,k+1,iCell)) / dz
-              uws(k,iCell) = -diff*(us(i1,k,iCell) - us(i1,k+1,iCell)) / dz
-              vws(k,iCell) = -diff*(vs(i1,k,iCell) - vs(i1,k+1,iCell)) / dz
-
-            enddo !nVertLevels
-          enddo !nCells
-
-!          if(config_adc_use_old_length_scale)then
-!					  call dissipation_lengths2(nCells,nVertLevels,activeTracers,alphaT,betaS)
-!          endif
-
-          !next all second order moment tendencies also apply tendencies
-          do iCell=1,nCells
-            do k=2,nVertLevels
-              dzmid = (zm(k-1,iCell) - zm(k,iCell))
-              dz = ze(k-1,iCell) - ze(k,iCell)
-              B = grav*(alphaT(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND - &
-                areaFraction(k,iCell))*wumd(k,iCell)*tumd(k,iCell) -      &
-                betaS(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND -          &
-                areaFraction(k,iCell))*wumd(k,iCell)*sumd(k,iCell))
-
-              Uz = (uvel(k-1,iCell) - uvel(k,iCell)) / dzmid
-              Vz = (vvel(k-1,iCell) - vvel(k,iCell)) / dzmid
-              Tz = (activeTracers(1,k-1,iCell) - activeTracers(1,k,iCell)) / dzmid
-              Sz = (activeTracers(2,k-1,iCell) - activeTracers(2,k,iCell)) / dzmid
-
-              KE = sqrt(0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + areaFraction(k,iCell)* &
-                        (1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2.0))
-
-              !tauTemp(k,iCell) = c_Temp*KE / (1.0E-15_RKIND + length(k,iCell))
-              !tauSalt(k,iCell) = c_Salt*KE / (1.0E-15_RKIND + length(k,iCell))
-              tau_tracer(k,iCell) = c_slow_tracer*KE / (1.0E-15_RKIND + length(k,iCell))
-              tauVel(k,iCell) = C_slow*KE / (1.0E-15_RKIND + length(k,iCell))
-              tauvVel(k,iCell) = slow_w_factor*C_slow*KE / (1.0E-15_RKIND + length(k,iCell))
-
-              w2tend1(k,iCell) = -wumd(k,iCell)**2.0_RKIND*(         &
-                Entrainment(k,iCell) + Detrainment(k,iCell))
-              w2tend2(k,iCell) = (McMid(k-1,iCell)*(1.0_RKIND - 2.0_RKIND* &
-                areaFractionMid(k-1,iCell))*wumdMid(k-1,iCell)**2.0 - McMid(k,iCell)* &
-                (1.0_RKIND - 2.0_RKIND*areaFractionMid(k,iCell))*wumdMid(k,iCell)**2.0) / dzmid
-              w2tend3(k,iCell) = tauvVel(k,iCell)*(u2(i1,k,iCell) + v2(i1,k,iCell))/3.0_RKIND
-              w2tend4(k,iCell) = (2.0_RKIND - 4.0_RKIND/3.0_RKIND*C_b)*Mc(k,iCell)* &
-                (grav*alphaT(k,iCell)*tumd(k,iCell) - grav*betaS(k,iCell)*sumd(k,iCell))
-              w2tend5(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 -            &
-                alpha_2)*(uw(i1,k,iCell)*Uz + vw(i1,k,iCell)*Vz) +         &
-                Mc(k,iCell)*(Swumd(k-1,iCell) + Swumd(k,iCell))
-
-              w2tend(i3_f,k,iCell) = w2tend1(k,iCell) + w2tend2(k,iCell) + &
-                w2tend3(k,iCell) + w2tend4(k,iCell) + w2tend5(k,iCell) + w2tend6(k,iCell)
-
-              wttend1(k,iCell) = -1.0_RKIND*(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
-                wumd(k,iCell)*tumd(k,iCell)
-              wttend2(k,iCell) = ((1.0_RKIND - 2.0_RKIND*areaFraction(k-1,iCell))* &
-                wumd(k-1,iCell)*tumd(k-1,iCell)*Mc(k-1,iCell) - (1.0_RKIND - 2.0_RKIND* &
-                areaFraction(k+1,iCell))*wumd(k+1,iCell)*tumd(k+1,iCell)*Mc(k+1,iCell)) &
-                / (ze(k-1,iCell) - ze(k+1,iCell)) - 0.0_RKIND*Mc(k,iCell)*wumd(k,iCell)*Tz
-              wttend2(k,iCell) = -(w2t(k-1,iCell) - w2t(k,iCell)) / (zm(k-1,iCell) - zm(k,iCell)) - &
-                  Mc(k,iCell)*wumd(k,iCell)*Tz*0.0_RKIND
-              wttend3(k,iCell) = (1.0_RKIND - C_b_tracer)*areaFraction(k,iCell)*  &
-                (1.0_RKIND - areaFraction(k,iCell))*grav*(alphaT(k,iCell) &
-                *tumd(k,iCell)**2.0 - betaS(k,iCell)*tumd(k,iCell)*sumd(k,iCell))
-              wttend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(ut(i1,k,iCell)*Uz + &
-                vt(i1,k,iCell)*Vz) - Mc(k,iCell)*wumd(k,iCell)*Tz
-              wttend5(k,iCell) = kappa_FL*(wt(i1,k-1,iCell) -       &
-                    wt(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0
-              wttend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
-                    tumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
-                    (1.0_RKIND / areaFraction(k,iCell) * (areaFraction(k-1,iCell)*wt_spsU(k-1,iCell) - &
-                    areaFraction(k+1,iCell)*wt_spsU(k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell)) - &
-                    1.0_RKIND/(1.0_RKIND - areaFraction(k,iCell))*((1.0_RKIND - areaFraction(k-1,iCell))* &
-                    wt_spsD(k-1,iCell) - (1.0_RKIND - areaFraction(k+1,iCell))*wt_spsD(k+1,iCell)) / &
-                    (ze(k-1,iCell) - ze(k+1,iCell)))
-
-              wttend(i3_f,k,iCell) = wttend1(k,iCell) + wttend2(k,iCell) +        &
-                wttend3(k,iCell) + wttend4(k,iCell) + wttend5(k,iCell) + wttend6(k,iCell)
-
-              wstend1(k,iCell) = -(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
-                wumd(k,iCell)*sumd(k,iCell)
-              wstend2(k,iCell) = ((1.0_RKIND - 2.0_RKIND*areaFraction(k-1,iCell))* &
-                wumd(k-1,iCell)*sumd(k-1,iCell)*Mc(k-1,iCell) - (1.0_RKIND - 2.0_RKIND* &
-                areaFraction(k+1,iCell))*wumd(k+1,iCell)*sumd(k+1,iCell)*Mc(k+1,iCell)) &
-                / (ze(k-1,iCell) - ze(k+1,iCell)) - Mc(k,iCell)*wumd(k,iCell)*Sz
-              wstend3(k,iCell) = (1.0_RKIND - C_b_tracer)*grav*areaFraction(k,iCell)* &
-                (1.0_RKIND - areaFraction(k,iCell))*(alphaT(k,iCell) &
-                *tumd(k,iCell)*sumd(k,iCell) - betaS(k,iCell)*sumd(k,iCell)*sumd(k,iCell))
-              wstend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + &
-                vs(i1,k,iCell)*Vz)
-              wstend5(k,iCell) = kappa_FL*(ws(i1,k-1,iCell) -       &
-                    ws(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0
-              wstend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
-                    sumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
-                    (1.0_RKIND / areaFraction(k,iCell) * (areaFraction(k-1,iCell)*ws_spsU(k-1,iCell) - &
-                    areaFraction(k+1,iCell)*ws_spsU(k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell)) - &
-                    1.0_RKIND/(1.0_RKIND - areaFraction(k,iCell))*((1.0_RKIND - areaFraction(k-1,iCell))* &
-                    ws_spsD(k-1,iCell) - (1.0_RKIND - areaFraction(k+1,iCell))*ws_spsD(k+1,iCell)) / &
-                    (ze(k-1,iCell) - ze(k+1,iCell)))
-
-              wstend(i3_f,k,iCell) = wstend1(k,iCell) + wstend2(k,iCell) + &
-                wstend3(k,iCell) + wstend4(k,iCell) + wstend5(k,iCell) + wstend6(k,iCell)
-
-              uwtend1(k,iCell) = -(uw2(k-1,iCell) - uw2(k,iCell)) / dzmid
-              uwtend2(k,iCell) = 0.5*((alpha_0 - 4.0*alpha_1/3.0)*KE**2.0 +  &
-                (alpha_1 - alpha_2)*u2(i1,k,iCell) + (alpha_1 +  &
-                alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Uz
-              uwtend3(k,iCell) = 0.5_RKIND*(alpha_1 - alpha_2)*    &
-                uv(i1,k,iCell)*Vz
-              uwtend4(k,iCell) = (1-C_b)*grav*(alphaT(k,iCell)*   &
-                ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell))
-              uwtend5(k,iCell) = -tauVel(k,iCell)*uw(i1,k,iCell) + &
-                kappa_FL*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
-                (ze(k-1,iCell) - ze(k+1,iCell))**2.0
-
-              uwtend(i3_f,k,iCell) = uwtend1(k,iCell) + uwtend2(k,iCell) + &
-                uwtend3(k,iCell) + uwtend4(k,iCell) + uwtend5(k,iCell)
-
-              vwtend(i3_f,k,iCell) = (-(vw2(k-1,iCell) - vw2(k,iCell)) / dzmid +   &
-                0.5_RKIND*((alpha_0 - 4.0*alpha_1/3.0)*KE**2.0_RKIND +  &
-                (alpha_1 - alpha_2)*v2(i1,k,iCell) + (alpha_1 +   &
-                alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Vz + 0.5_RKIND*(alpha_1 &
-                - alpha_2)*uv(i1,k,iCell)*Uz + (1-C_b)*grav*       &
-                (alphaT(k,iCell)*vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))) -            &
-                tauVel(k,iCell)*vw(i1,k,iCell) + kappa_FL*(vw(i1,k-1,iCell) &
-                - vw(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0
-
-              uvtend(i3_f,k,iCell) = (-(uvw(k-1,iCell) - uvw(k,iCell)) / dz - &
-                (1.0_RKIND - 0.5_RKIND*(alpha_1+alpha_2))*(uw(i1,k,iCell)*Vz &
-                + vw(i1,k,iCell)*Uz)) - tauVel(k,iCell)*uv(i1,k,iCell) +           &
-                kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) /       &
-                (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
-
-              u2tend1(k,iCell) = -(u2w(k-1,iCell) - u2w(k,iCell)) / dzmid
-              u2tend2(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2 - &
-                2.0_RKIND)*uw(i1,k,iCell)*Uz
-              u2tend3(k,iCell) = - 2.0_RKIND/3.0_RKIND*alpha_1*vw(i1,k,iCell)*Vz
-              u2tend4(k,iCell) = 2.0_RKIND/3.0_RKIND*C_b*B
-!              u2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell) + &
-!                tauVel(k,iCell)*(KE**2.0_RKIND/3.0_RKIND - u2(i1,k,iCell))
-              u2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell) + &
-                tauVel(k,iCell)*(v2(i1,k,iCell) + areaFraction(k,iCell)*( &
-                1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND
-
-              u2tend(i3_f,k,iCell) = u2tend1(k,iCell) + u2tend2(k,iCell) + &
-                u2tend3(k,iCell) + u2tend4(k,iCell) + u2tend5(k,iCell) + u2tend6(k,iCell)
-
-              v2tend1(k,iCell) = -(v2w(k-1,iCell) - v2w(k,iCell)) / dzmid
-              v2tend2(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2 - &
-                2.0_RKIND)*vw(i1,k,iCell)*Vz
-              v2tend3(k,iCell) = - 2.0_RKIND/3.0_RKIND*alpha_1*uw(i1,k,iCell)*Uz
-              v2tend4(k,iCell) = 2.0_RKIND/3.0_RKIND*C_b*B
-!              v2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell) + tauVel(k,iCell)* &
-!                (KE**2/3. - v2(i1,k,iCell))
-              v2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell) + &
-                tauVel(k,iCell)*(u2(i1,k,iCell) + areaFraction(k,iCell)*( &
-                1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND
-
-              v2tend(i3_f,k,iCell) = v2tend1(k,iCell) + v2tend2(k,iCell) + &
-                v2tend3(k,iCell) + v2tend4(k,iCell) + v2tend5(k,iCell) + v2tend6(k,iCell)
-
-              uttend(i3_f,k,iCell) = (-(uwt(k-1,iCell) - uwt(k,iCell))/dz -  &
-                uw(i1,k,iCell)*Tz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
-                alpha_tracer2))*wt(i1,k,iCell)*Uz) - ut(i1,k,iCell)*tau_tracer(k,iCell)
-
-              vttend(i3_f,k,iCell) = (-(vwt(k-1,iCell) - vwt(k,iCell))/dz -  &
-                vw(i1,k,iCell)*Tz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
-                alpha_tracer2))*wt(i1,k,iCell)*Vz) - vt(i1,k,iCell)*tau_tracer(k,iCell)
-
-              ustend(i3_f,k,iCell) = (-(uws(k-1,iCell) - uws(k,iCell))/dz -  &
-                uw(i1,k,iCell)*Sz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
-                alpha_tracer2))*ws(i1,k,iCell)*Uz) - us(i1,k,iCell)*tau_tracer(k,ICell)
-
-              vstend(i3_f,k,iCell) = (-(vws(k-1,iCell) - vws(k,iCell))/dz -  &
-                vw(i1,k,iCell)*Sz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
-                alpha_tracer2))*ws(i1,k,iCell)*Vz) - vs(i1,k,iCell)*tau_tracer(k,iCell)
-
-              t2(i2,k,iCell) = tumd(k,iCell)**2.0_RKIND*areaFraction(k,iCell)*&
-                (1.0_RKIND-areaFraction(k,iCell))
-              s2(i2,k,iCell) = sumd(k,iCell)**2.0_RKIND*areaFraction(k,iCell)*&
-                (1.0_RKIND-areaFraction(k,iCell))
-              ts(i2,k,iCell) = tumd(k,iCell)*sumd(k,iCell)* &
-                areaFraction(k,iCell)*(1.0_RKIND-areaFraction(k,iCell))
-
-              if(.not. config_adc_use_old_length_scale)then
-              !epsilon tendency is next
-              KEm1 = 0.5_RKIND*(u2(i1,k-1,iCell) + v2(i1,k-1,iCell) + w2(i1,k-1,iCell))
-              KE = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell))
-              KEp1 = 0.5_RKIND*(u2(i1,k+1,iCell) + v2(i1,k+1,iCell) + w2(i1,k+1,iCell))
-              tauM1 = 2.0_RKIND*KEm1 / (eps(i1,k-1,iCell) + 1.0E-15_RKIND)
-              tau = 2.0_RKIND*KE / (eps(i1,k,iCell) + 1.0E-15_RKIND)
-              tauP1 = 2.0_RKIND*KEp1 / (eps(i1,k+1,iCell) + 1.0E-15_RKIND)
-              tauAV = 0.5_RKIND*(tauUP + tauDN)
-
-              tomUP = 0.5577/1.3_RKIND*(0.5_RKIND*(KEm1+KE))**2/(0.5_RKIND*(eps(i1,k-1,iCell) + &
-                eps(i1,k,iCell)) + 1.0E-15_RKIND)*(eps(i1,k-1,iCell) - &
-                eps(i1,k,iCell)) / (ze(k-1,iCell) - ze(k,iCell) + 1.0E-10_RKIND)
-              tomDN = 0.5577/1.3_RKIND*(0.5_RKIND*(KE+KEp1))**2/(0.5_RKIND*(eps(i1,k,iCell) + &
-                eps(i1,k+1,iCell)) + 1.0E-15_RKIND)*(eps(i1,k,iCell) - &
-                eps(i1,k+1,iCell)) / (ze(k,iCell) - ze(k+1,iCell) + 1.0E-10_RKIND)
-
-              epstend(i3_f,k,iCell) = (tomUP - tomDN) / (zm(k-1,iCell) - zm(k,iCell) + 1.0E-10_RKIND) - &
-              !-0.8_RKIND*((tomUP / (0.5_RKIND*(tauM1 + tau) + 1.0E-10_RKIND) - tomDN / &
-               ! (0.5_RKIND*(tau + tauP1) + 1.0E-10_RKIND)) / (zm(k-1,iCell) - zm(k,iCell))) - &
-                2.88/(tau + 1.0E-10_RKIND)*uw(i1,k,iCell)*(uvel(k-1,iCell) - uvel(k,iCell)) / &
-                (zm(k-1,iCell) - zm(k,iCell)) - &
-                2.88/(tau + 1.0E-10_RKIND)*vw(i1,k,iCell)*(vvel(k-1,iCell) - vvel(k,iCell)) / &
-                (zm(k-1,iCell) - zm(k,iCell)) + &
-                2.88/(tau + 1.0E-10_RKIND)*grav*(alphaT(k,iCell)*wt(i1,k,iCell) - betaS(k,iCell)* &
-                ws(i1,k,iCell)) - 3.84*eps(i1,k,iCell)/(tau + 1.0E-10_RKIND)
-              endif
-
-              !finally update all subplume fluxes
-              if(BVF(k,iCell) <= 0.0_RKIND) then
-                lenspsU(k,iCell) = dzmid
-                lenspsD(k,iCell) = dzmid
-              else
-                lenspsU(k,iCell) = min(dz,0.76_RKIND*sqrt(KspsU(i1,k,iCell)/BVF(k,iCell)))
-                lenspsD(k,iCell) = min(dz,0.76_RKIND*sqrt(KspsD(i1,k,iCell)/BVF(k,iCell)))
-              endif
-
-              KmU(k,iCell) = 0.1_RKIND*lenspsU(k,iCell)*sqrt( KspsU(i1,k,iCell) )
-              KhU(k,iCell) = ( 1.0_RKIND+2.0_RKIND*lenspsU(k,iCell)/dz)*KmU(k,iCell)
-              wt_spsU(k,iCell) =  -KhU(k,iCell)*Tz
-              ws_spsU(k,iCell) =  -KhU(k,iCell)*Sz
-
-              KmD(k,iCell) = 0.1_RKIND*lenspsD(k,iCell)*sqrt( KspsD(i1,k,iCell) )
-              KhD(k,iCell) = ( 1.0_RKIND+2.0_RKIND*lenspsD(k,iCell)/dz)*KmD(k,iCell)
-              wt_spsD(k,iCell) = -KhD(k,iCell)*Tz
-              ws_spsD(k,iCell) = -KhD(k,iCell)*Sz
-
-              if(k==2) then
-                Cval = 3.96
-              else
-                Cval = (0.19_RKIND+0.51_RKIND*lenspsU(k,iCell)/dzmid)
-              endif
-
-              KspsUtend(i3_f,k,iCell) = grav*(alphaT(k,iCell)*wt_spsU(k,iCell) - &
-                betaS(k,iCell)*ws_spsU(k,ICell)) + ((KmU(k-1,iCell) +                 &
-                KmU(k,iCell))*(KspsU(i1,k-1,iCell) - KspsU(i1,k,iCell)) /         &
-                (ze(k-1,iCell) - ze(k,iCell)) - (KmU(k,iCell) +             &
-                KmU(k+1,iCell)) * (KspsU(i1,k,iCell) - KspsU(i1,k+1,iCell)) /     &
-                (ze(k,iCell) - ze(k+1,iCell))) / dzmid -                                 &
-                Cval*KspsU(i1,k,iCell)**1.5_RKIND/(1.0E-15 + lenspsU(k,iCell)) +                     &
-                eps(i1,k,iCell) / (2.0_RKIND*(1.0_RKIND - areaFraction(k,iCell))) + KmU(k,iCell)* &
-                (Uz**2.0 + Vz**2.0)
-
-              if(k==2) then
-                Cval = 3.96_RKIND
-              else
-                Cval = (0.19_RKIND+0.51_RKIND*lenspsD(k,iCell)/dz)
-              endif
-
-              KspsDtend(i3_f,k,iCell) = grav*(alphaT(k,iCell)*wt_spsD(k,iCell) - &
-                betaS(k,iCell)*ws_spsD(k,iCell)) + ((KmD(k-1,iCell) +                 &
-                KmD(k,iCell))*(KspsD(i1,k-1,iCell) - KspsD(i1,k,iCell)) /         &
-                (ze(k-1,iCell) - ze(k,iCell)) - (KmD(k,iCell) +             &
-                KmD(k+1,iCell)) * (KspsD(i1,k,iCell) - KspsD(i1,k+1,iCell)) /     &
-                (ze(k,iCell) - ze(k+1,iCell))) / dz -                                 &
-                Cval*KspsD(i1,k,iCell)**1.5_RKIND /(1.0E-15_RKIND + lenspsD(k,iCell)) +                   &
-                eps(i1,k,iCell) / (2.0_RKIND*(areaFraction(k,iCell))) + &
-                KmD(k,iCell)*(Uz**2.0 + Vz**2.0)
-
-            enddo ! nVertLevels
-          enddo ! nCells
-
-          !In this step we update second moments except w3 which needs updated w2
-          do iCell = 1,nCells
-            do k=2,nVertLevels
-                !update second order moment tendency here
-                w2(i2,k,iCell) = (w2(i1,k,iCell) + dt_small*(Cw3 * w2tend(i3_f,k,iCell)  &
-                  + Cw2 * w2tend(i2_f,k,iCell) + Cw1 * w2tend(i1_f,k,iCell))) /           &
-                  (1.0_RKIND + dt_small*tauvVel(k,iCell)*2.0_RKIND/3.0_RKIND)
-                if(w2(i2,k,iCell) < epsilon) then
-                  w2cliptend(k,iCell) = epsilon - w2(i2,k,iCell)
-                  w2(i2,k,iCell) = epsilon
-                endif
-
-                if(abs(w2(i2,k,iCell)) > 1.0_RKIND) then
-                   call mpas_log_write("ERROR: w2 out of range, w2 = $r, location = $i, $i", &
-                    MPAS_LOG_CRIT,realArgs=(/w2(i2,k,iCell)/),intArgs=(/k,iCell/))
-                endif
-
-                u2(i2,k,iCell) = (u2(i1,k,iCell) + dt_small*(Cw3 * u2tend(i3_f,k,iCell) +  &
-                  Cw2 * u2tend(i2_f,k,iCell) + Cw1 * u2tend(i1_f,k,iCell))) /          &
-                  (1.0_RKIND + dt_small*tauVel(k,iCell)*2.0_RKIND/3.0_RKIND)
-                if(u2(i2,k,iCell) < epsilon) then
-                   u2cliptend(k,iCell) = epsilon - u2(i2,k,iCell)
-                   u2(i2,k,iCell) = epsilon
-                endif
-
-                v2(i2,k,iCell) = (v2(i1,k,iCell) + dt_small*(Cw3 * v2tend(i3_f,k,iCell) + &
-                  Cw2 * v2tend(i1_f,k,iCell) + Cw1 * v2tend(i1_f,k,iCell))) /              &
-                  (1.0_RKIND + dt_small*tauVel(k,iCell)*2.0_RKIND/3.0_RKIND)
-                if(v2(i2,k,iCell) < epsilon) then
-                   v2cliptend(k,iCell) = epsilon - v2(i2,k,iCell)
-                   v2(i2,k,iCell) = epsilon
-                endif
-
-                uw(i2,k,iCell) = uw(i1,k,iCell) + dt_small*(Cw3 * uwtend(i3_f,k,iCell) + &
-                  Cw2 * uwtend(i2_f,k,iCell) + Cw1 * uwtend(i1_f,k,iCell))
-                vw(i2,k,iCell) = vw(i1,k,iCell) + dt_small*(Cw3 * vwtend(i3_f,k,iCell) + &
-                  Cw2 * vwtend(i2_f,k,iCell) + Cw1 * vwtend(i1_f,k,iCell))
-                uv(i2,k,iCell) = uv(i1,k,iCell) + dt_small*(Cw3 * uvtend(i3_f,k,iCell) + &
-                  Cw2 * uvtend(i2_f,k,iCell) + Cw1 * uvtend(i1_f,k,iCell))
-                ut(i2,k,iCell) = ut(i1,k,iCell) + dt_small*(Cw3 * uttend(i3_f,k,iCell) + &
-                  Cw2 * uttend(i2_f,k,iCell) + Cw1 * uttend(i1_f,k,iCell))
-                wt(i2,k,iCell) = (wt(i1,k,iCell) + dt_small*(Cw3 * wttend(i3_f,k,iCell) + &
-                  Cw2 * wttend(i2_f,k,iCell) + Cw1 * wttend(i1_f,k,iCell))) /              &
-                  (1.0_RKIND + dt_small*tau_tracer(k,iCell))
-                vt(i2,k,iCell) = vt(i1,k,iCell) + dt_small*(Cw3 * vttend(i3_f,k,iCell) + &
-                  Cw2 * vttend(i2_f,k,iCell) + Cw1 * vttend(i1_f,k,iCell))
-                us(i2,k,iCell) = us(i1,k,iCell) + dt_small*(Cw3 * ustend(i3_f,k,iCell) + &
-                  Cw2 * ustend(i2_f,k,iCell) + Cw1 * ustend(i1_f,k,iCell))
-                vs(i2,k,iCell) = vs(i1,k,iCell) + dt_small*(Cw3 * vstend(i3_f,k,iCell) + &
-                  Cw2 * vstend(i2_f,k,iCell) + Cw1 * vstend(i1_f,k,iCell))
-                ws(i2,k,iCell) = (ws(i1,k,iCell) + dt_small*(Cw3 * wstend(i3_f,k,iCell) + &
-                  Cw2 * wstend(i2_f,k,iCell) + Cw1 * wstend(i1_f,k,iCell))) /              &
-                   (1.0_RKIND + dt_small*tau_tracer(k,iCell))
-                if(abs(wt(i2,k,iCell)) > 1.0_RKIND) then
-                  call mpas_log_write("ERROR: wt out of range, wt = $r, location = $i, $i", &
-                     MPAS_LOG_CRIT,realArgs=(/wt(i2,k,iCell)/),intArgs=(/k,iCell/))
-                 endif
-
-                if(abs(ws(i2,k,iCell)) > 1.0_RKIND) then
-                   call mpas_log_write("ERROR: ws out of range, ws = $r, location = $i, $i", &
-                     MPAS_LOG_CRIT,realArgs=(/ws(i2,k,iCell)/),intArgs=(/k,iCell/))
-                endif
-
-                if(abs(u2(i2,k,iCell)) > 1.0_RKIND) then
-                   call mpas_log_write("ERROR: u2 out of range, u2 = $r, location = $i, $i", &
-                     MPAS_LOG_CRIT,realArgs=(/u2(i2,k,iCell)/),intArgs=(/k,iCell/))
-                endif
-
-                if(abs(v2(i2,k,iCell)) > 1.0_RKIND) then
-                   call mpas_log_write("ERROR: v2 out of range, v2 = $r, location = $i, $i", &
-                     MPAS_LOG_CRIT,realArgs=(/v2(i2,k,iCell)/),intArgs=(/k,iCell/))
-                endif
-
-                if(.not. config_adc_use_old_length_scale)then
-                   eps(i2,k,iCell) = eps(i1,k,iCell) + dt_small*(Cw3 * epstend(i3_f,k,iCell) + &
-                     Cw2 * epstend(i2_f,k,iCell) + Cw1 * epstend(i1_f,k,iCell))
-                   if (eps(i2,k,iCell) < 1.0E-10_RKIND) then
-                      eps(i2,k,iCell) = 1.0E-10_RKIND
-                   endif
-                   !Amrapalli: 16.6 here can be tuned if needed, would show up in u2 and v2 primarily
-                   ! also in KEspsU/D
-                   KE = 0.5_RKIND*(u2(i2,k,iCell) + v2(i2,k,iCell) + w2(i2,k,iCell))
-                   length(k,iCell) = KE**1.5 / (c_epsilon * eps(i2,k,iCell))
+                    d_sqrt_wp2_dz = (sqrt(w2(i1,k,iCell)) - sqrt(w2(i1,k+1,iCell))) / &
+                      (ze(k,iCell) - ze(k+1,iCell))
+                    w3tend6(1,iCell) = min(max(-config_adc_splat_tend_max, -w3(i1,k,iCell)*         &
+                      config_adc_splat_wp2_val*tau_sfc*d_sqrt_wp2_dz**2), &
+                      config_adc_splat_tend_max)
+                 end do
+              end do
+
+              do iCell=1,nCells
+                 tp2 = 0.4_RKIND * config_adc_bc_const * (wt(i1,1,iCell) / frictionVelocity)**2
+                 sp2 = 0.4_RKIND * config_adc_bc_const * (ws(i1,1,iCell) / frictionVelocity)**2
+                 min_wp2_sfc_val = max(1.0E-10_RKIND, wt(i1,1,iCell)**2 / (tp2 * 0.99_RKIND**2 + 1.0E-15_RKIND), &
+                   ws(i1,1,iCell)**2 / (sp2 * 0.99_RKIND**2 + 1.0E-15_RKIND))
+                 tau_sfc = length(1,iCell) / sqrt(0.5_RKIND*(u2(i1,1,iCell) + v2(i1,1,iCell)))
+
+                 if(w2(i1,1,iCell) + tau_sfc * w2tend6(1,iCell) < min_wps_sfc_val) then
+                    wp2_splat_sfc_correction = -w2(i1,1,iCell) + min_wp2_sfc_val
+                    w2(i1,1,iCell) = min_wp2_sfc_val
                  else
-                   KE = 0.5_RKIND*(u2(i2,k,iCell) + v2(i2,k,iCell) + w2(i2,k,iCell))
-                   eps(:,k,iCell) = KE**1.5 / (c_epsilon * length(k,iCell))
+                    wp2_splat_sfc_correction = tau_sfc * w2tend6(1,iCell)
+                    w2(i1,1,iCell) = w2(i1,1,iCell) + wp2_splat_sfc_correction
+                 end if
+                 u2(i1,1,iCell) = u2(i1,1,iCell) - 0.5_RKIND * wp2_splat_sfc_correction
+                 v2(i1,1,iCell) = v2(i1,1,iCell) - 0.5_RKIND * wp2_splat_sfc_correction
+              end do
+
+!     build up splat tend for u2 and v2
+              do iCell=1,nCells
+                 do k=2,nVertLevels
+                    u2tend6(k,iCell) = -0.5_RKIND*w2tend6(k,iCell)
+                    v2tend6(k,iCell) = -0.5_RKIND*w2tend6(k,iCell)
+                 end do
+              end do
+           else
+              do iCell=1,nCells
+                 do k=1,nVertLevels
+                    w3tend6(k,iCell) = 0.0_RKIND
+                    w2tend6(k,iCell) = 0.0_RKIND
+                    u2tend6(k,iCell) = 0.0_RKIND
+                    v2tend6(k,iCell) = 0.0_RKIND
+                 end do
+              end do
+           end if               ! end use splat correction
+
+
+!     Kernel 1 inlined versions of the base arrays, needed for later to make them collapsible
+           do iCell=1,nCells
+              do k=2,nVertLevels
+                 w3av = 0.5_RKIND*(w3(i1,k-1,iCell) + w3(i1,k,iCell))
+
+                 Sw = w3av / (w2(i1,k,iCell)**1.5_RKIND + 1.0E-15_RKIND)
+                 lareaFraction = 0.5_RKIND + 0.5_RKIND*Sw / sqrt(4.0_RKIND + Sw**2)
+
+                 if(lareaFraction < 0.01_RKIND) then
+                    lareaFraction = 0.01_RKIND
+                 end if
+
+                 if(lareaFraction > 0.99_RKIND) then
+                    lareaFraction = 0.99_RKIND
+                 end if
+
+                 areaFraction(k,iCell) = lareaFraction
+
+                 wumd(k,iCell) = sqrt(w2(i1,k,iCell) / (areaFraction(k,iCell) * &
+                   (1.0_RKIND - areaFraction(k,iCell))))
+                 Mc(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - &
+                   areaFraction(k,iCell)) * wumd(k,iCell)
+
+                 tumd(k,iCell) = wt(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
+                 sumd(k,iCell) = ws(i1,k,iCell) / (1.0E-12_RKIND + Mc(k,iCell))
+
+                 if(w2(i1,k,iCell) <= epsilon + 1.0e-9) then
+                    tumd(k,iCell) = 0.0_RKIND
+                    sumd(k,iCell) = 0.0_RKIND
                  endif
-                KspsU(i2,k,iCell) = max(epsilon,KspsU(i1,k,iCell) + dt_small*(Cw3 * &
-                  KspsUtend(i3_f,k,iCell) + Cw2 * KspsUtend(i2_f,k,iCell) + Cw1 *    &
-                  KspsUtend(i1_f,k,iCell)))
-                KspsD(i2,k,iCell) = max(epsilon,KspsD(i1,k,iCell) + dt_small*(Cw3 * &
-                  KspsDtend(i3_f,k,iCell) + Cw2 * KspsDtend(i2_f,k,iCell) + Cw1 *    &
-                  KspsDtend(i1_f,k,iCell)))
+!     redo mid quantities
+                 areaFractionMid(k-1,iCell) = 0.5_RKIND*(areaFraction(k-1,iCell) + areaFraction(k,iCell))
+                 wumdMid(k-1,iCell) = 0.5_RKIND*(wumd(k-1,iCell) + wumd(k,iCell))
+                 tumdMid(k-1,iCell) = 0.5_RKIND*(tumd(k-1,iCell) + tumd(k,iCell))
+                 sumdMid(k-1,iCell) = 0.5_RKIND*(sumd(k-1,iCell) + sumd(k,iCell))
+                 McMid(k-1,iCell) = 0.5_RKIND*(Mc(k-1,iCell) + Mc(k,iCell))
+              enddo
+              areaFractionMid(nVertLevels,iCell) = 0.5_RKIND
+              wumdMid(nVertLevels,iCell) = 0.0_RKIND
+              tumdMid(nVertLevels,iCell) = 0.0_RKIND
+              sumdMid(nVertLevels,iCell) = 0.0_RKIND
+              McMid(nVertLevels,iCell) = 0.0_RKIND
+           enddo
 
-            enddo !nVertLevels
-          enddo !nCells for second order moment tendencies
+           do iCell = 1,nCells
+              do k=2,nVertLevels
+                 sigav = 0.5_RKIND*(areaFraction(k,iCell) + areaFraction(k+1,iCell))
+                 tumdav = 0.5_RKIND*(tumd(k,iCell) + tumd(k+1,iCell))
+                 sumdav = 0.5_RKIND*(sumd(k,iCell) + sumd(k+1,iCell))
+                 wumdav = 0.5_RKIND*(wumd(k,iCell) + wumd(k+1,iCell))
+                 sigav = areaFractionMid(k,iCell)
+                 tumdav = tumdMid(k,iCell)
+                 wumdav = wumdMid(k,iCell)
+                 sumdav = sumdMid(k,iCell)
+                 w2tTemp = -sigav*(1.0_RKIND - sigav)*(1.0_RKIND - 2.0_RKIND*sigav)*wumdav**2.0_RKIND*tumdav
+                 w2tCheck = sigav*(1.0_RKIND - sigav)*sqrt(1.0_RKIND - 3.0_RKIND*sigav + 3.0_RKIND*sigav**2)* &
+                   wumdav**2.0*tumdav
+                 w2t(k,iCell) = w2tTemp
 
-          ! update the third order w3 and mean fields
-          do iCell = 1,nCells
-!            w3(i2,1,iCell) = (w3(i1,1,iCell) + dt_small*(Cw3 * w3tend(i3_f,1,iCell) + &
-!               Cw2 * w3tend(i2_f,1,iCell) + Cw1 * w3tend(i1_f,1,iCell))) / &
-!              (1.0_RKIND + 0.0*dt_small*tauw3(1,iCell))
-            do k=1,nVertLevels
-              w3check = (w2(i2,k,iCell) + w2(i2,k+1,iCell))**1.5
-              if(w3check < 3e-14_RKIND) w3check = 1.0
-              w3(i2,k,iCell) = max(-w3check,min((w3(i1,k,iCell) + dt_small*(Cw3 * w3tend(i3_f,k,iCell) + &
-                Cw2 * w3tend(i2_f,k,iCell) + Cw1 * w3tend(i1_f,k,iCell))) / &
-                (1.0_RKIND + 0.0*dt_small*tauw3(k,iCell)),w3check))
+                 w2sTemp = -sigav*(1.0_RKIND - sigav)*(1.0_RKIND - 2.0_RKIND*sigav)*wumdav**2.0_RKIND*sumdav
+                 w2sCheck = sigav*(1.0_RKIND - sigav)*sqrt(1.0_RKIND - 3.0_RKIND*sigav + 3.0_RKIND*sigav**2)* &
+                   wumdav**2.0*sumdav
+                 w2s(k,iCell) = w2sTemp
+
+!     also use this loop to reset the cliptends for the step
+                 u2cliptend(k,iCell) = 0.0_RKIND
+                 v2cliptend(k,iCell) = 0.0_RKIND
+                 w2cliptend(k,iCell) = 0.0_RKIND
+              enddo
+           enddo
+           if(config_adc_use_old_length_scale)then
+              call dissipation_lengths2(nCells,nVertLevels,activeTracers,alphaT,betaS)
+           endif
+           do iCell = 1,nCells
+              do k=1,nVertLevels
+!     change length scale to lenup and lendown
+                 Entrainment(k,iCell) = Cww_E*areaFraction(k,iCell)*(1.0_RKIND- &
+                   areaFraction(k,iCell))*Mc(k,iCell) / ( lenup(k,iCell) + 1.0E-15_RKIND )
+                 Detrainment(k,iCell) = Cww_D*areaFraction(k,iCell)*(1.0_RKIND- &
+                   areaFraction(k,iCell))*Mc(k,iCell) / ( lendn(k,iCell) +1.0E-15_RKIND )
+              enddo
+           enddo
+
+!     This cell loop computes w3Tend and TOMs for later tendencies.  Should be okay to collapse loops here
+           do iCell = 1,nCells
+              do k=1,nVertLevels
+                 Eav = 0.5*(Entrainment(k+1,iCell) + Entrainment(k,iCell))
+                 Dav = 0.5*(Detrainment(k+1,iCell) + Detrainment(k,iCell))
+                 u2av = 0.5*(u2(i1,k,iCell) + u2(i1,k+1,iCell))
+                 v2av = 0.5*(v2(i1,k,iCell) + v2(i1,k+1,iCell))
+                 w2av = 0.5*(w2(i1,k,iCell) + w2(i1,k+1,iCell))
+
+                 sigav = 0.5*(areaFraction(k,iCell) + areaFraction(k+1,iCell))
+                 wumdav = 0.5*(wumd(k,iCell) + wumd(k+1,iCell))
+                 tumdav = 0.5*(tumd(k,iCell) + tumd(k+1,iCell))
+                 sumdav = 0.5*(sumd(k,iCell) + sumd(k+1,iCell))
+                 Mcav = 0.5*(Mc(k,iCell) + Mc(k+1,iCell))
+                 lenav = 0.5*(length(k,iCell) + length(k+1,iCell))
+                 KE = sqrt(0.5_RKIND*(u2av+v2av+w2av))
+
+                 dz = ze(k,iCell) - ze(k+1,iCell)
+                 Swumd(k,iCell) = - 2.0/3.0*(1.0_RKIND/sigav*(areaFraction(k,iCell)*KspsD(i1,k,iCell) - &
+                   areaFraction(k+1,iCell)*KspsD(i1,k+1,iCell)) / dz - 1.0_RKIND / (1.0_RKIND - &
+                   sigav)*((1.0_RKIND - areaFraction(k,iCell))*KspsU(i1,k,iCell) - (1.0_RKIND - &
+                   areaFraction(k+1,iCell))*KspsU(i1,k+1,iCell)) / dz)
+
+                 tauw3(k,iCell) = C_mom_w3*KE / (1.0E-15_RKIND + sqrt(2.0_RKIND)*lenAv)
+
+                 wumdav = wumdMid(k,ICell)
+                 sigav = areaFractionMid(k,iCell)
+                 Mcav = McMid(k,iCell)
+                 
+                 w3tend1(k,iCell) = -wumdav**3.0*(Eav*(3.0*sigav - 2.0) + Dav*(3.0*sigav - 1.0))
+
+                 Swk   =  -(1.0_RKIND-2.0_RKIND*sigav)/(sigav*(1.0_RKIND-sigav))**0.5
+                 w3tend2(k,iCell) = -((3.0_RKIND + Swk**2.0)*(w2(i1,k,iCell)**2.0) - &
+                   (3.0_RKIND + Swk**2.0)*(w2(i1,k+1,iCell)**2.0) ) / dz
+                 w3tend3(k,iCell) = 1.5_RKIND*(w2(i1,k,iCell)**2.0 - w2(i1,k+1,iCell)**2.0) / dz
+
+                 w3tend4(k,iCell) = -3.0_RKIND*(1.0_RKIND - 2.0_RKIND*sigav)*Mcav*wumdav*Swumd(k,iCell) - &
+                   tauw3(k,iCell)*w3(i1,k,iCell)
+                 w3tend5(k,iCell) = 3.0_RKIND*(1.0_RKIND - c11)*grav*(alphaT(k,iCell)*w2t(k,iCell) - &
+                   betaS(k,iCell)*w2s(k,iCell))
+
+                 w3tend(i3_f,k,iCell) = w3tend1(k,iCell) + w3tend2(k,iCell) + w3tend3(k,iCell) + &
+                 w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell)
+
+                 if(k>1 .and. k < nVertLevels .and. kappa_w3 > 0.0) then
+                    w3tend(i3_f,k,iCell) = w3tend(i3_f,k,iCell) + kappa_w3*(w3(i1,k-1,iCell) &
+                      - w3(i1,k+1,iCell)) / (zm(k-1,iCell) - zm(k+1,iCell))**2.0
+                 endif
+
+!     now get all the downgradient TOMs
+                 KE = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell))
+                 KEp1 = 0.5_RKIND*(u2(i1,k+1,iCell) + v2(i1,k+1,iCell) + w2(i1,k+1,iCell))
+                 lenav = 0.5_RKIND*(length(k,iCell) + length(k+1,iCell))
+                 diff = C_mom * sqrt(0.5_RKIND*(KE + KEp1)) * lenav
+                 dz = ze(k,iCell) - ze(k+1,iCell)
+                 uw2(k,iCell) = -diff*(uw(i1,k,iCell) - uw(i1,k+1,iCell)) / dz
+                 vw2(k,iCell) = -diff*(vw(i1,k,iCell) - vw(i1,k+1,iCell)) / dz
+                 u2w(k,iCell) = -diff*(u2(i1,k,iCell) - u2(i1,k+1,iCell)) / dz
+                 v2w(k,iCell) = -diff*(v2(i1,k,iCell) - v2(i1,k+1,iCell)) / dz
+                 uvw(k,iCell) = -diff*(uv(i1,k,iCell) - uv(i1,k+1,iCell)) / dz
+
+                 diff = C_therm*sqrt(0.5*(KE + KEp1)) * lenav
+                 uwt(k,iCell) = -diff*(ut(i1,k,iCell) - ut(i1,k+1,iCell)) / dz
+                 vwt(k,iCell) = -diff*(vt(i1,k,iCell) - vt(i1,k+1,iCell)) / dz
+                 uws(k,iCell) = -diff*(us(i1,k,iCell) - us(i1,k+1,iCell)) / dz
+                 vws(k,iCell) = -diff*(vs(i1,k,iCell) - vs(i1,k+1,iCell)) / dz
+
+              enddo             !nVertLevels
+           enddo                !nCells
+
+!     next all second order moment tendencies also apply tendencies
+           do iCell=1,nCells
+              do k=2,nVertLevels
+                 dzmid = (zm(k-1,iCell) - zm(k,iCell))
+                 dz = ze(k-1,iCell) - ze(k,iCell)
+                 B = grav*(alphaT(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND - &
+                   areaFraction(k,iCell))*wumd(k,iCell)*tumd(k,iCell) -      &
+                   betaS(k,iCell)*areaFraction(k,iCell)*(1.0_RKIND -          &
+                   areaFraction(k,iCell))*wumd(k,iCell)*sumd(k,iCell))
+
+                 Uz = (uvel(k-1,iCell) - uvel(k,iCell)) / dzmid
+                 Vz = (vvel(k-1,iCell) - vvel(k,iCell)) / dzmid
+                 Tz = (activeTracers(1,k-1,iCell) - activeTracers(1,k,iCell)) / dzmid
+                 Sz = (activeTracers(2,k-1,iCell) - activeTracers(2,k,iCell)) / dzmid
+                 
+                 KE = sqrt(0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + areaFraction(k,iCell)* &
+                   (1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2.0))
+
+                 tau_tracer(k,iCell) = c_slow_tracer*KE / (1.0E-15_RKIND + length(k,iCell))
+                 tauVel(k,iCell) = C_slow*KE / (1.0E-15_RKIND + length(k,iCell))
+                 tauvVel(k,iCell) = slow_w_factor*C_slow*KE / (1.0E-15_RKIND + length(k,iCell))
+
+                 w2tend1(k,iCell) = -wumd(k,iCell)**2.0_RKIND*(         &
+                   Entrainment(k,iCell) + Detrainment(k,iCell))
+                 w2tend2(k,iCell) = (McMid(k-1,iCell)*(1.0_RKIND - 2.0_RKIND* &
+                   areaFractionMid(k-1,iCell))*wumdMid(k-1,iCell)**2.0 - McMid(k,iCell)* &
+                   (1.0_RKIND - 2.0_RKIND*areaFractionMid(k,iCell))*wumdMid(k,iCell)**2.0) / dzmid
+                 w2tend3(k,iCell) = tauvVel(k,iCell)*(u2(i1,k,iCell) + v2(i1,k,iCell))/3.0_RKIND
+                 w2tend4(k,iCell) = (2.0_RKIND - 4.0_RKIND/3.0_RKIND*C_b)*Mc(k,iCell)* &
+                   (grav*alphaT(k,iCell)*tumd(k,iCell) - grav*betaS(k,iCell)*sumd(k,iCell))
+                 w2tend5(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 -            &
+                   alpha_2)*(uw(i1,k,iCell)*Uz + vw(i1,k,iCell)*Vz) +         &
+                   Mc(k,iCell)*(Swumd(k-1,iCell) + Swumd(k,iCell))
+
+                 w2tend(i3_f,k,iCell) = w2tend1(k,iCell) + w2tend2(k,iCell) + &
+                 w2tend3(k,iCell) + w2tend4(k,iCell) + w2tend5(k,iCell) + w2tend6(k,iCell)
+
+                 wttend1(k,iCell) = -1.0_RKIND*(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
+                   wumd(k,iCell)*tumd(k,iCell)
+                 wttend2(k,iCell) = ((1.0_RKIND - 2.0_RKIND*areaFraction(k-1,iCell))* &
+                   wumd(k-1,iCell)*tumd(k-1,iCell)*Mc(k-1,iCell) - (1.0_RKIND - 2.0_RKIND* &
+                   areaFraction(k+1,iCell))*wumd(k+1,iCell)*tumd(k+1,iCell)*Mc(k+1,iCell)) &
+                   / (ze(k-1,iCell) - ze(k+1,iCell)) - 0.0_RKIND*Mc(k,iCell)*wumd(k,iCell)*Tz
+                 wttend2(k,iCell) = -(w2t(k-1,iCell) - w2t(k,iCell)) / (zm(k-1,iCell) - zm(k,iCell)) - &
+                   Mc(k,iCell)*wumd(k,iCell)*Tz*0.0_RKIND
+                 wttend3(k,iCell) = (1.0_RKIND - C_b_tracer)*areaFraction(k,iCell)*  &
+                   (1.0_RKIND - areaFraction(k,iCell))*grav*(alphaT(k,iCell) &
+                   *tumd(k,iCell)**2.0 - betaS(k,iCell)*tumd(k,iCell)*sumd(k,iCell))
+                 wttend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(ut(i1,k,iCell)*Uz + &
+                   vt(i1,k,iCell)*Vz) - Mc(k,iCell)*wumd(k,iCell)*Tz
+                 wttend5(k,iCell) = kappa_FL*(wt(i1,k-1,iCell) -       &
+                   wt(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0
+                 wttend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
+                   tumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
+                   (1.0_RKIND / areaFraction(k,iCell) * (areaFraction(k-1,iCell)*wt_spsU(k-1,iCell) - &
+                   areaFraction(k+1,iCell)*wt_spsU(k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))  &
+                   -1.0_RKIND/(1.0_RKIND - areaFraction(k,iCell))*((1.0_RKIND - areaFraction(k-1,iCell))* &
+                   wt_spsD(k-1,iCell) - (1.0_RKIND - areaFraction(k+1,iCell))*wt_spsD(k+1,iCell)) / &
+                   (ze(k-1,iCell) - ze(k+1,iCell)))
+
+                 wttend(i3_f,k,iCell) = wttend1(k,iCell) + wttend2(k,iCell) +        &
+                   wttend3(k,iCell) + wttend4(k,iCell) + wttend5(k,iCell) + wttend6(k,iCell)
+
+                 wstend1(k,iCell) = -(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
+                   wumd(k,iCell)*sumd(k,iCell)
+                 wstend2(k,iCell) = ((1.0_RKIND - 2.0_RKIND*areaFraction(k-1,iCell))* &
+                   wumd(k-1,iCell)*sumd(k-1,iCell)*Mc(k-1,iCell) - (1.0_RKIND - 2.0_RKIND* &
+                   areaFraction(k+1,iCell))*wumd(k+1,iCell)*sumd(k+1,iCell)*Mc(k+1,iCell)) &
+                   / (ze(k-1,iCell) - ze(k+1,iCell)) - Mc(k,iCell)*wumd(k,iCell)*Sz
+                 wstend3(k,iCell) = (1.0_RKIND - C_b_tracer)*grav*areaFraction(k,iCell)* &
+                   (1.0_RKIND - areaFraction(k,iCell))*(alphaT(k,iCell) &
+                   *tumd(k,iCell)*sumd(k,iCell) - betaS(k,iCell)*sumd(k,iCell)*sumd(k,iCell))
+                 wstend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + &
+                   vs(i1,k,iCell)*Vz)
+                 wstend5(k,iCell) = kappa_FL*(ws(i1,k-1,iCell) -       &
+                   ws(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0
+                 wstend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
+                   sumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
+                   (1.0_RKIND / areaFraction(k,iCell) * (areaFraction(k-1,iCell)*ws_spsU(k-1,iCell) - &
+                   areaFraction(k+1,iCell)*ws_spsU(k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))  &
+                   -1.0_RKIND/(1.0_RKIND - areaFraction(k,iCell))*((1.0_RKIND - areaFraction(k-1,iCell))* &
+                   ws_spsD(k-1,iCell) - (1.0_RKIND - areaFraction(k+1,iCell))*ws_spsD(k+1,iCell)) / &
+                   (ze(k-1,iCell) - ze(k+1,iCell)))
+
+                 wstend(i3_f,k,iCell) = wstend1(k,iCell) + wstend2(k,iCell) + &
+                   wstend3(k,iCell) + wstend4(k,iCell) + wstend5(k,iCell) + wstend6(k,iCell)
+
+                 uwtend1(k,iCell) = -(uw2(k-1,iCell) - uw2(k,iCell)) / dzmid
+                 uwtend2(k,iCell) = 0.5*((alpha_0 - 4.0*alpha_1/3.0)*KE**2.0 +  &
+                   (alpha_1 - alpha_2)*u2(i1,k,iCell) + (alpha_1 +  &
+                   alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Uz
+                 uwtend3(k,iCell) = 0.5_RKIND*(alpha_1 - alpha_2)*    &
+                   uv(i1,k,iCell)*Vz
+                 uwtend4(k,iCell) = (1-C_b)*grav*(alphaT(k,iCell)*   &
+                   ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell))
+                 uwtend5(k,iCell) = -tauVel(k,iCell)*uw(i1,k,iCell) + &
+                   kappa_FL*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
+                   (ze(k-1,iCell) - ze(k+1,iCell))**2.0
+
+                 uwtend(i3_f,k,iCell) = uwtend1(k,iCell) + uwtend2(k,iCell) + &
+                   uwtend3(k,iCell) + uwtend4(k,iCell) + uwtend5(k,iCell)
+
+                 vwtend(i3_f,k,iCell) = (-(vw2(k-1,iCell) - vw2(k,iCell)) / dzmid  &
+                   + 0.5_RKIND*((alpha_0 - 4.0*alpha_1/3.0)*KE**2.0_RKIND +  &
+                   (alpha_1 - alpha_2)*v2(i1,k,iCell) + (alpha_1 +   &
+                   alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Vz + 0.5_RKIND*(alpha_1 &
+                   - alpha_2)*uv(i1,k,iCell)*Uz + (1-C_b)*grav*       &
+                   (alphaT(k,iCell)*vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))) -            &
+                   tauVel(k,iCell)*vw(i1,k,iCell) + kappa_FL*(vw(i1,k-1,iCell) &
+                   - vw(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0
+
+                 uvtend(i3_f,k,iCell) = (-(uvw(k-1,iCell) - uvw(k,iCell)) / dz - &
+                   (1.0_RKIND - 0.5_RKIND*(alpha_1+alpha_2))*(uw(i1,k,iCell)*Vz &
+                   + vw(i1,k,iCell)*Uz)) - tauVel(k,iCell)*uv(i1,k,iCell) +           &
+                   kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) /       &
+                   (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
+
+                 u2tend1(k,iCell) = -(u2w(k-1,iCell) - u2w(k,iCell)) / dzmid
+                 u2tend2(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2 &
+                   -2.0_RKIND)*uw(i1,k,iCell)*Uz
+                 u2tend3(k,iCell) = - 2.0_RKIND/3.0_RKIND*alpha_1*vw(i1,k,iCell)*Vz
+                 u2tend4(k,iCell) = 2.0_RKIND/3.0_RKIND*C_b*B
+                 u2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell) + &
+                   tauVel(k,iCell)*(v2(i1,k,iCell) + areaFraction(k,iCell)* &
+                   (1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND
+
+                 u2tend(i3_f,k,iCell) = u2tend1(k,iCell) + u2tend2(k,iCell) + &
+                   u2tend3(k,iCell) + u2tend4(k,iCell) + u2tend5(k,iCell) + u2tend6(k,iCell)
+
+                 v2tend1(k,iCell) = -(v2w(k-1,iCell) - v2w(k,iCell)) / dzmid
+                 v2tend2(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2 &
+                   - 2.0_RKIND)*vw(i1,k,iCell)*Vz
+                 v2tend3(k,iCell) = - 2.0_RKIND/3.0_RKIND*alpha_1*uw(i1,k,iCell)*Uz
+                 v2tend4(k,iCell) = 2.0_RKIND/3.0_RKIND*C_b*B
+                 v2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell) + &
+                   tauVel(k,iCell)*(u2(i1,k,iCell) + areaFraction(k,iCell)* &
+                   (1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND
+
+                 v2tend(i3_f,k,iCell) = v2tend1(k,iCell) + v2tend2(k,iCell) + &
+                   v2tend3(k,iCell) + v2tend4(k,iCell) + v2tend5(k,iCell) + v2tend6(k,iCell)
+
+                 uttend(i3_f,k,iCell) = (-(uwt(k-1,iCell) - uwt(k,iCell))/dz -  &
+                   uw(i1,k,iCell)*Tz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
+                   alpha_tracer2))*wt(i1,k,iCell)*Uz) - ut(i1,k,iCell)*tau_tracer(k,iCell)
+
+                 vttend(i3_f,k,iCell) = (-(vwt(k-1,iCell) - vwt(k,iCell))/dz -  &
+                   vw(i1,k,iCell)*Tz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
+                   alpha_tracer2))*wt(i1,k,iCell)*Vz) - vt(i1,k,iCell)*tau_tracer(k,iCell)
+
+                 ustend(i3_f,k,iCell) = (-(uws(k-1,iCell) - uws(k,iCell))/dz -  &
+                   uw(i1,k,iCell)*Sz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
+                   alpha_tracer2))*ws(i1,k,iCell)*Uz) - us(i1,k,iCell)*tau_tracer(k,ICell)
+                   
+                 vstend(i3_f,k,iCell) = (-(vws(k-1,iCell) - vws(k,iCell))/dz -  &
+                   vw(i1,k,iCell)*Sz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
+                   alpha_tracer2))*ws(i1,k,iCell)*Vz) - vs(i1,k,iCell)*tau_tracer(k,iCell)
+
+                 t2(i2,k,iCell) = tumd(k,iCell)**2.0_RKIND*areaFraction(k,iCell)*&
+                   (1.0_RKIND-areaFraction(k,iCell))
+                 s2(i2,k,iCell) = sumd(k,iCell)**2.0_RKIND*areaFraction(k,iCell)*&
+                   (1.0_RKIND-areaFraction(k,iCell))
+                 ts(i2,k,iCell) = tumd(k,iCell)*sumd(k,iCell)* &
+                   areaFraction(k,iCell)*(1.0_RKIND-areaFraction(k,iCell))
+
+                 if(.not. config_adc_use_old_length_scale)then
+!     epsilon tendency is next
+                    KEm1 = 0.5_RKIND*(u2(i1,k-1,iCell) + v2(i1,k-1,iCell) + w2(i1,k-1,iCell))
+                    KE = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell))
+                    KEp1 = 0.5_RKIND*(u2(i1,k+1,iCell) + v2(i1,k+1,iCell) + w2(i1,k+1,iCell))
+                    tauM1 = 2.0_RKIND*KEm1 / (eps(i1,k-1,iCell) + 1.0E-15_RKIND)
+                    tau = 2.0_RKIND*KE / (eps(i1,k,iCell) + 1.0E-15_RKIND)
+                    tauP1 = 2.0_RKIND*KEp1 / (eps(i1,k+1,iCell) + 1.0E-15_RKIND)
+                    tauAV = 0.5_RKIND*(tauUP + tauDN)
+                    
+                    tomUP = 0.5577/1.3_RKIND*(0.5_RKIND*(KEm1+KE))**2/(0.5_RKIND*(eps(i1,k-1,iCell) + &
+                      eps(i1,k,iCell)) + 1.0E-15_RKIND)*(eps(i1,k-1,iCell) - &
+                      eps(i1,k,iCell)) / (ze(k-1,iCell) - ze(k,iCell) + 1.0E-10_RKIND)
+                    tomDN = 0.5577/1.3_RKIND*(0.5_RKIND*(KE+KEp1))**2/(0.5_RKIND*(eps(i1,k,iCell) + &
+                      eps(i1,k+1,iCell)) + 1.0E-15_RKIND)*(eps(i1,k,iCell) - &
+                      eps(i1,k+1,iCell)) / (ze(k,iCell) - ze(k+1,iCell) + 1.0E-10_RKIND)
+                    
+                    epstend(i3_f,k,iCell) = (tomUP - tomDN) / (zm(k-1,iCell) - zm(k,iCell) + 1.0E-10_RKIND) &
+                      - 2.88/(tau + 1.0E-10_RKIND)*uw(i1,k,iCell)*(uvel(k-1,iCell) - uvel(k,iCell)) / &
+                      (zm(k-1,iCell) - zm(k,iCell)) &
+                      - 2.88/(tau + 1.0E-10_RKIND)*vw(i1,k,iCell)*(vvel(k-1,iCell) - vvel(k,iCell)) / &
+                      (zm(k-1,iCell) - zm(k,iCell)) &
+                      + 2.88/(tau + 1.0E-10_RKIND)*grav*(alphaT(k,iCell)*wt(i1,k,iCell) - betaS(k,iCell)* &
+                      ws(i1,k,iCell)) - 3.84*eps(i1,k,iCell)/(tau + 1.0E-10_RKIND)
+                 endif
+
+!     finally update all subplume fluxes
+                 if(BVF(k,iCell) <= 0.0_RKIND) then
+                    lenspsU(k,iCell) = dzmid
+                    lenspsD(k,iCell) = dzmid
+                 else
+                    lenspsU(k,iCell) = min(dz,0.76_RKIND*sqrt(KspsU(i1,k,iCell)/BVF(k,iCell)))
+                    lenspsD(k,iCell) = min(dz,0.76_RKIND*sqrt(KspsD(i1,k,iCell)/BVF(k,iCell)))
+                 endif
+
+                 KmU(k,iCell) = 0.1_RKIND*lenspsU(k,iCell)*sqrt( KspsU(i1,k,iCell) )
+                 KhU(k,iCell) = ( 1.0_RKIND+2.0_RKIND*lenspsU(k,iCell)/dz)*KmU(k,iCell)
+                 wt_spsU(k,iCell) =  -KhU(k,iCell)*Tz
+                 ws_spsU(k,iCell) =  -KhU(k,iCell)*Sz
+                 
+                 KmD(k,iCell) = 0.1_RKIND*lenspsD(k,iCell)*sqrt( KspsD(i1,k,iCell) )
+                 KhD(k,iCell) = ( 1.0_RKIND+2.0_RKIND*lenspsD(k,iCell)/dz)*KmD(k,iCell)
+                 wt_spsD(k,iCell) = -KhD(k,iCell)*Tz
+                 ws_spsD(k,iCell) = -KhD(k,iCell)*Sz
+
+                 if(k==2) then
+                    Cval = 3.96
+                 else
+                    Cval = (0.19_RKIND+0.51_RKIND*lenspsU(k,iCell)/dzmid)
+                 endif
+
+                 KspsUtend(i3_f,k,iCell) = grav*(alphaT(k,iCell)*wt_spsU(k,iCell) - &
+                   betaS(k,iCell)*ws_spsU(k,ICell)) + ((KmU(k-1,iCell) +                 &
+                   KmU(k,iCell))*(KspsU(i1,k-1,iCell) - KspsU(i1,k,iCell)) /         &
+                   (ze(k-1,iCell) - ze(k,iCell)) - (KmU(k,iCell) +             &
+                   KmU(k+1,iCell)) * (KspsU(i1,k,iCell) - KspsU(i1,k+1,iCell)) /     &
+                   (ze(k,iCell) - ze(k+1,iCell))) / dzmid -                                 &
+                   Cval*KspsU(i1,k,iCell)**1.5_RKIND/(1.0E-15 + lenspsU(k,iCell)) +                     &
+                   eps(i1,k,iCell) / (2.0_RKIND*(1.0_RKIND - areaFraction(k,iCell))) + KmU(k,iCell)* &
+                   (Uz**2.0 + Vz**2.0)
+
+                 if(k==2) then
+                    Cval = 3.96_RKIND
+                 else
+                    Cval = (0.19_RKIND+0.51_RKIND*lenspsD(k,iCell)/dz)
+                 endif
+
+                 KspsDtend(i3_f,k,iCell) = grav*(alphaT(k,iCell)*wt_spsD(k,iCell) - &
+                   betaS(k,iCell)*ws_spsD(k,iCell)) + ((KmD(k-1,iCell) +                 &
+                   KmD(k,iCell))*(KspsD(i1,k-1,iCell) - KspsD(i1,k,iCell)) /         &
+                   (ze(k-1,iCell) - ze(k,iCell)) - (KmD(k,iCell) +             &
+                   KmD(k+1,iCell)) * (KspsD(i1,k,iCell) - KspsD(i1,k+1,iCell)) /     &
+                   (ze(k,iCell) - ze(k+1,iCell))) / dz -                                 &
+                   Cval*KspsD(i1,k,iCell)**1.5_RKIND /(1.0E-15_RKIND + lenspsD(k,iCell)) +                   &
+                   eps(i1,k,iCell) / (2.0_RKIND*(areaFraction(k,iCell))) + &
+                   KmD(k,iCell)*(Uz**2.0 + Vz**2.0)
+
+              enddo           ! nVertLevels
+           enddo                ! nCells
+
+!     In this step we update second moments except w3 which needs updated w2
+           do iCell = 1,nCells
+              do k=2,nVertLevels
+!     update second order moment tendency here
+                 w2(i2,k,iCell) = (w2(i1,k,iCell) + dt_small*(Cw3 * w2tend(i3_f,k,iCell)  &
+                   + Cw2 * w2tend(i2_f,k,iCell) + Cw1 * w2tend(i1_f,k,iCell))) /           &
+                   (1.0_RKIND + dt_small*tauvVel(k,iCell)*2.0_RKIND/3.0_RKIND)
+                 if(w2(i2,k,iCell) < epsilon) then
+                    w2cliptend(k,iCell) = epsilon - w2(i2,k,iCell)
+                    w2(i2,k,iCell) = epsilon
+                 endif
+
+                 if(abs(w2(i2,k,iCell)) > 1.0_RKIND) then
+                    call mpas_log_write("ERROR: w2 out of range, w2 = $r, location = $i, $i", &
+                    MPAS_LOG_CRIT,realArgs=(/w2(i2,k,iCell)/),intArgs=(/k,iCell/))
+                 endif
+
+                 u2(i2,k,iCell) = (u2(i1,k,iCell) + dt_small*(Cw3 * u2tend(i3_f,k,iCell) +  &
+                   Cw2 * u2tend(i2_f,k,iCell) + Cw1 * u2tend(i1_f,k,iCell))) /          &
+                   (1.0_RKIND + dt_small*tauVel(k,iCell)*2.0_RKIND/3.0_RKIND)
+                 if(u2(i2,k,iCell) < epsilon) then
+                    u2cliptend(k,iCell) = epsilon - u2(i2,k,iCell)
+                    u2(i2,k,iCell) = epsilon
+                 endif
+
+                 v2(i2,k,iCell) = (v2(i1,k,iCell) + dt_small*(Cw3 * v2tend(i3_f,k,iCell) + &
+                   Cw2 * v2tend(i1_f,k,iCell) + Cw1 * v2tend(i1_f,k,iCell))) /              &
+                   (1.0_RKIND + dt_small*tauVel(k,iCell)*2.0_RKIND/3.0_RKIND)
+                 if(v2(i2,k,iCell) < epsilon) then
+                    v2cliptend(k,iCell) = epsilon - v2(i2,k,iCell)
+                    v2(i2,k,iCell) = epsilon
+                 endif
+
+                 uw(i2,k,iCell) = uw(i1,k,iCell) + dt_small*(Cw3 * uwtend(i3_f,k,iCell) + &
+                   Cw2 * uwtend(i2_f,k,iCell) + Cw1 * uwtend(i1_f,k,iCell))
+                 vw(i2,k,iCell) = vw(i1,k,iCell) + dt_small*(Cw3 * vwtend(i3_f,k,iCell) + &
+                   Cw2 * vwtend(i2_f,k,iCell) + Cw1 * vwtend(i1_f,k,iCell))
+                 uv(i2,k,iCell) = uv(i1,k,iCell) + dt_small*(Cw3 * uvtend(i3_f,k,iCell) + &
+                   Cw2 * uvtend(i2_f,k,iCell) + Cw1 * uvtend(i1_f,k,iCell))
+                 ut(i2,k,iCell) = ut(i1,k,iCell) + dt_small*(Cw3 * uttend(i3_f,k,iCell) + &
+                   Cw2 * uttend(i2_f,k,iCell) + Cw1 * uttend(i1_f,k,iCell))
+                 wt(i2,k,iCell) = (wt(i1,k,iCell) + dt_small*(Cw3 * wttend(i3_f,k,iCell) + &
+                   Cw2 * wttend(i2_f,k,iCell) + Cw1 * wttend(i1_f,k,iCell))) /              &
+                   (1.0_RKIND + dt_small*tau_tracer(k,iCell))
+                 vt(i2,k,iCell) = vt(i1,k,iCell) + dt_small*(Cw3 * vttend(i3_f,k,iCell) + &
+                   Cw2 * vttend(i2_f,k,iCell) + Cw1 * vttend(i1_f,k,iCell))
+                 us(i2,k,iCell) = us(i1,k,iCell) + dt_small*(Cw3 * ustend(i3_f,k,iCell) + &
+                   Cw2 * ustend(i2_f,k,iCell) + Cw1 * ustend(i1_f,k,iCell))
+                 vs(i2,k,iCell) = vs(i1,k,iCell) + dt_small*(Cw3 * vstend(i3_f,k,iCell) + &
+                   Cw2 * vstend(i2_f,k,iCell) + Cw1 * vstend(i1_f,k,iCell))
+                 ws(i2,k,iCell) = (ws(i1,k,iCell) + dt_small*(Cw3 * wstend(i3_f,k,iCell) + &
+                   Cw2 * wstend(i2_f,k,iCell) + Cw1 * wstend(i1_f,k,iCell))) /              &
+                   (1.0_RKIND + dt_small*tau_tracer(k,iCell))
+                 if(abs(wt(i2,k,iCell)) > 1.0_RKIND) then
+                    call mpas_log_write("ERROR: wt out of range, wt = $r, location = $i, $i", &
+                      MPAS_LOG_CRIT,realArgs=(/wt(i2,k,iCell)/),intArgs=(/k,iCell/))
+                 endif
+                 
+                 if(abs(ws(i2,k,iCell)) > 1.0_RKIND) then
+                    call mpas_log_write("ERROR: ws out of range, ws = $r, location = $i, $i", &
+                      MPAS_LOG_CRIT,realArgs=(/ws(i2,k,iCell)/),intArgs=(/k,iCell/))
+                 endif
+                 
+                 if(abs(u2(i2,k,iCell)) > 1.0_RKIND) then
+                    call mpas_log_write("ERROR: u2 out of range, u2 = $r, location = $i, $i", &
+                      MPAS_LOG_CRIT,realArgs=(/u2(i2,k,iCell)/),intArgs=(/k,iCell/))
+                 endif
+
+                 if(abs(v2(i2,k,iCell)) > 1.0_RKIND) then
+                    call mpas_log_write("ERROR: v2 out of range, v2 = $r, location = $i, $i", &
+                      MPAS_LOG_CRIT,realArgs=(/v2(i2,k,iCell)/),intArgs=(/k,iCell/))
+                 endif
+
+                 if(.not. config_adc_use_old_length_scale)then
+                    eps(i2,k,iCell) = eps(i1,k,iCell) + dt_small*(Cw3 * epstend(i3_f,k,iCell) + &
+                      Cw2 * epstend(i2_f,k,iCell) + Cw1 * epstend(i1_f,k,iCell))
+                    if (eps(i2,k,iCell) < 1.0E-10_RKIND) then
+                       eps(i2,k,iCell) = 1.0E-10_RKIND
+                    endif
+!     Amrapalli: 16.6 here can be tuned if needed, would show up in u2 and v2 primarily
+!     also in KEspsU/D
+                    KE = 0.5_RKIND*(u2(i2,k,iCell) + v2(i2,k,iCell) + w2(i2,k,iCell))
+                    length(k,iCell) = KE**1.5 / (c_epsilon * eps(i2,k,iCell))
+                 else
+                    KE = 0.5_RKIND*(u2(i2,k,iCell) + v2(i2,k,iCell) + w2(i2,k,iCell))
+                    eps(:,k,iCell) = KE**1.5 / (c_epsilon * length(k,iCell))
+                 endif
+                 KspsU(i2,k,iCell) = max(epsilon,KspsU(i1,k,iCell) + dt_small*(Cw3 * &
+                   KspsUtend(i3_f,k,iCell) + Cw2 * KspsUtend(i2_f,k,iCell) + Cw1 *    &
+                   KspsUtend(i1_f,k,iCell)))
+                 KspsD(i2,k,iCell) = max(epsilon,KspsD(i1,k,iCell) + dt_small*(Cw3 * &
+                   KspsDtend(i3_f,k,iCell) + Cw2 * KspsDtend(i2_f,k,iCell) + Cw1 *    &
+                   KspsDtend(i1_f,k,iCell)))
+
+              enddo           !nVertLevels
+           enddo                !nCells for second order moment tendencies
+
+!     update the third order w3 and mean fields
+           do iCell = 1,nCells
+              do k=1,nVertLevels
+                 w3check = (w2(i2,k,iCell) + w2(i2,k+1,iCell))**1.5
+                 if(w3check < 3e-14_RKIND) w3check = 1.0
+                 w3(i2,k,iCell) = max(-w3check,min((w3(i1,k,iCell) + dt_small*(Cw3 * w3tend(i3_f,k,iCell) + &
+                   Cw2 * w3tend(i2_f,k,iCell) + Cw1 * w3tend(i1_f,k,iCell))) / &
+                   (1.0_RKIND + 0.0*dt_small*tauw3(k,iCell)),w3check))
 
 
-              if(abs(w3(i2,k,iCell)) > 1.0_RKIND) then
-                call mpas_log_write("ERROR: w3 out of range, w3 = $r, location = $i, $i", &
-                  MPAS_LOG_CRIT,realArgs=(/w3(i2,k,iCell)/),intArgs=(/k,iCell/))
-              endif
-            enddo
-          enddo
-                iterCount = iterCount + 1
-      call get_array_pointers
-      call get_weights
-!  enddo !end iteration loop -- substepping is done.
-    !now that substepping is done, apply computed fluxes to update mean fields.
-    !you can collapse this loop too.
-    do iCell = 1, nCells
-      do k=1,nVertLevels
-          utemp = uvel(k,iCell)
-          vtemp = vvel(k,iCell)
-          uvel(k,iCell) = uvel(k,iCell) - dt_small*(uw(i1,k,iCell) - uw(i1,k+1,iCell)) /  &
-                    (ze(k,iCell) - ze(k+1,iCell)) !+ dt_small*fCell(iCell)*vtemp
+                 if(abs(w3(i2,k,iCell)) > 1.0_RKIND) then
+                    call mpas_log_write("ERROR: w3 out of range, w3 = $r, location = $i, $i", &
+                      MPAS_LOG_CRIT,realArgs=(/w3(i2,k,iCell)/),intArgs=(/k,iCell/))
+                 endif
+              enddo
+           enddo
+           iterCount = iterCount + 1
+           call get_array_pointers
+           call get_weights
+!     enddo !end iteration loop -- substepping is done.
+!     now that substepping is done, apply computed fluxes to update mean fields.
+!     you can collapse this loop too.
+           do iCell = 1, nCells
+              do k=1,nVertLevels
+                 utemp = uvel(k,iCell)
+                 vtemp = vvel(k,iCell)
+                 uvel(k,iCell) = uvel(k,iCell) - dt_small*(uw(i1,k,iCell) - uw(i1,k+1,iCell)) /  &
+                   (ze(k,iCell) - ze(k+1,iCell)) !+ dt_small*fCell(iCell)*vtemp
 
-          vvel(k,iCell) = vvel(k,iCell) - dt_small*(vw(i1,k,iCell) - vw(i1,k+1,iCell)) /  &
-                    (ze(k,iCell) - ze(k+1,iCell)) !- dt_small*fCell(iCell)*utemp
-
-          wtSumUp = wt(i1,k,iCell) + areaFraction(k,iCell)*wt_spsD(k,iCell) + &
-            (1.0_RKIND - areaFraction(k,iCell))*wt_spsU(k,iCell)
-          wtSumDn = wt(i1,k+1,iCell) + areaFraction(k+1,iCell)*wt_spsD(k+1,iCell) + &
-            (1.0_RKIND - areaFraction(k+1,iCell))*wt_spsU(k+1,iCell)
-          wsSumUp = ws(i1,k,iCell) + areaFraction(k,iCell)*ws_spsD(k,iCell) + &
-            (1.0_RKIND - areaFraction(k,iCell))*ws_spsU(k,iCell)
-          wsSumDn = ws(i1,k+1,iCell) + areaFraction(k+1,iCell)*ws_spsU(k+1,iCell) + &
-            (1.0_RKIND - areaFraction(k+1,iCell))*ws_spsD(k+1,iCell)
-
-          activeTracers(1,k,iCell) = activeTracers(1,k,iCell) - dt_small*(wtSumUp - &
-            wtSumDn) / (ze(k,iCell) - ze(k+1,iCell))
-          activeTracers(2,k,iCell) = activeTracers(2,k,iCell) - dt_small*(wsSumUp - &
-            wsSumDn) / (ze(k,iCell) - ze(k+1,iCell))
-      enddo
-    enddo
-  enddo
-  end subroutine compute_ADC_tends
+                 vvel(k,iCell) = vvel(k,iCell) - dt_small*(vw(i1,k,iCell) - vw(i1,k+1,iCell)) /  &
+                   (ze(k,iCell) - ze(k+1,iCell)) !- dt_small*fCell(iCell)*utemp
+                 
+                 wtSumUp = wt(i1,k,iCell) + areaFraction(k,iCell)*wt_spsD(k,iCell) + &
+                   (1.0_RKIND - areaFraction(k,iCell))*wt_spsU(k,iCell)
+                 wtSumDn = wt(i1,k+1,iCell) + areaFraction(k+1,iCell)*wt_spsD(k+1,iCell) + &
+                   (1.0_RKIND - areaFraction(k+1,iCell))*wt_spsU(k+1,iCell)
+                 wsSumUp = ws(i1,k,iCell) + areaFraction(k,iCell)*ws_spsD(k,iCell) + &
+                   (1.0_RKIND - areaFraction(k,iCell))*ws_spsU(k,iCell)
+                 wsSumDn = ws(i1,k+1,iCell) + areaFraction(k+1,iCell)*ws_spsU(k+1,iCell) + &
+                   (1.0_RKIND - areaFraction(k+1,iCell))*ws_spsD(k+1,iCell)
+                 
+                 activeTracers(1,k,iCell) = activeTracers(1,k,iCell) - dt_small*(wtSumUp - &
+                   wtSumDn) / (ze(k,iCell) - ze(k+1,iCell))
+                 activeTracers(2,k,iCell) = activeTracers(2,k,iCell) - dt_small*(wsSumUp - &
+                   wsSumDn) / (ze(k,iCell) - ze(k+1,iCell))
+              enddo
+           enddo
+        enddo
+ end subroutine compute_ADC_tends
 
 end module ocn_adc_mixing_fused

--- a/src/core_ocean/shared/mpas_ocn_turbulence.F
+++ b/src/core_ocean/shared/mpas_ocn_turbulence.F
@@ -47,7 +47,7 @@ module ocn_turbulence
                        sigmat, Ko, c_b, c_b_tracer, alpha_tracer1, alpha_tracer2, c11, &
                        alpha_0, alpha_1, alpha_2, B1, Kt, grav, c_mom, &
                        c_therm, c_mom_w3, c_epsilon, c_slow, c_slow_tracer, slow_w_factor, &
-                       kappa_FL, kappa_w3, kappa_VAR, Cww_D, Cww_E
+                       kappa_FL, kappa_w3, kappa_VAR, Cww_D, Cww_E, adcRound
 
    integer,public :: iterCount, nCells, nVertLevels
 
@@ -174,6 +174,7 @@ module ocn_turbulence
       kappa_FL = config_adc_kappaFL
       kappa_VAR = config_adc_kappaVAR
       kappa_w3 = config_adc_kappaW3
+      adcRound = 10.0_RKIND**config_adc_decimals_to_keep
       iterCount = 1
 
       call mpas_pool_get_array(adcDiagnosticsPool, 'ze', zeTmp)

--- a/src/core_ocean/shared/mpas_ocn_vmix_adc.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_adc.F
@@ -142,7 +142,8 @@ contains
         normalVelocity, layerThickness, velocityZonal, velocityMeridional, &
         tracerGroupSurfaceFlux, tracerGroupSurfaceFluxRunoff, &
         tracerGroupSurfaceFluxRemoved, BruntVaisalaFreqTop,  &
-        inSituThermalExpansionCoeff, inSituSalineContractionCoeff
+        inSituThermalExpansionCoeff, inSituSalineContractionCoeff, &
+        velocityZonalCM, velocityMeridionalCM
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       integer, pointer :: indexTemperature, indexSalinity
@@ -153,12 +154,15 @@ contains
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
       integer, dimension(:,:), pointer :: cellsOnEdge
      real (kind=RKIND), dimension(:), allocatable :: zonalAverage, meridionalAverage, uw_sfc, &
-                           vw_sfc, ws_sfc, wt_sfc
+                           vw_sfc, ws_sfc, wt_sfc, uw_sfcCM, vw_sfcCM, ws_sfcCM, wt_sfcCM, &
+                           dThreshMLDCM
 
       real (kind=RKIND), dimension(:,:), allocatable :: utend, vtend, ttend, stend
       real (kind=RKIND) :: fac, dep1, dep2, fracAbsorbed, fracAbsorbedRunoff,  &
                            etime
 
+      real (kind=RKIND) :: MtoCM, KGtoG
+                           
       !-----------------------------------------------------------------
       !
       ! call relevant routines for computing mixing-related fields
@@ -171,6 +175,12 @@ contains
       ! assume no errors during initialization and set to 1 when error is encountered
       !
       err=0
+
+      if (config_adc_convert_to_CGS) then
+         MtoCM = 1000.0_RKIND
+      else
+         MtoCM = 1.0_RKIND
+      endif
 
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
@@ -229,7 +239,6 @@ contains
       ! need to use RBFs to get stress at cell centers
       call mpas_pool_get_array(forcingPool, 'windStressZonal', stressZonal)
       call mpas_pool_get_array(forcingPool, 'windStressMeridional', stressMeridional)
-
       call mpas_pool_get_array(forcingPool, 'surfaceStress', surfaceStress)
       call mpas_pool_get_array(forcingPool, 'surfaceStressMagnitude', surfaceStressMagnitude)
 
@@ -239,8 +248,11 @@ contains
       nEdges = nEdgesArray( 3 )
 
       allocate(uw_sfc(nCells), vw_sfc(nCells), ws_sfc(nCells), wt_sfc(nCells))
+      allocate(uw_sfcCM(nCells), vw_sfcCM(nCells), ws_sfcCM(nCells), wt_sfcCM(nCells))
+      allocate(dThreshMLDCM(nCells))
       allocate(utend(nVertLevels,nCells), vtend(nVertLevels,nCells))
       allocate(ttend(nVertLevels,nCells), stend(nVertLevels,nCells))
+      allocate(velocityZonalCM(nVertLevels,nCells), velocityMeridionalCM(nVertLevels,nCells))
 
       !$omp do schedule(runtime)
       do iEdge=1,nEdges
@@ -304,13 +316,13 @@ contains
          vw_sfc(iCell) = stressMeridional(iCell) / rho_sw
 
          ze(1,iCell) = 0.0_RKIND
-         zm(1,iCell) = -layerThickness(1,iCell)/2.0_RKIND
+         zm(1,iCell) = -MtoCM*layerThickness(1,iCell)/2.0_RKIND
          do k=2,maxLevelCell(iCell)
-            ze(k,iCell) = ze(k-1,iCell) - layerThickness(k-1,iCell)
-            zm(k,iCell) = ze(k, iCell) - layerThickness(k,iCell)/2.0_RKIND
+            ze(k,iCell) = ze(k-1,iCell) - MtoCM*layerThickness(k-1,iCell)
+            zm(k,iCell) = ze(k, iCell) - MtoCM*layerThickness(k,iCell)/2.0_RKIND
          enddo
          k = maxLevelCell(iCell)+1
-         ze(k,iCell) = ze(k-1,iCell) - layerThickness(k-1,iCell)
+         ze(k,iCell) = ze(k-1,iCell) - MtoCM*layerThickness(k-1,iCell)
          do k = maxLevelCell(iCell) + 1, nVertLevels
             ze(k+1,iCell) = ze(maxLevelCell(iCell)+1,iCell)
             zm(k,iCell) = ze(maxLevelCell(iCell)+1,iCell)
@@ -333,9 +345,20 @@ contains
      ttend(:,:nCells) = activeTracers(1,:,:nCells)
      stend(:,:nCells) = activeTracers(2,:,:nCells)
 
-     call compute_ADC_tends(local_nCells, nVertLevels, ntracers, dt, activeTracers, velocityZonal, velocityMeridional, &
-         BruntVaisalaFreqTop, uw_sfc, vw_sfc, wt_sfc, ws_sfc, inSituThermalExpansionCoeff,        &
-          inSituSalineContractionCoeff, fCell, dThreshMLD)
+     velocityZonalCM(:,:nCells) = MtoCM*velocityZonal(:,:nCells)
+     velocityMeridionalCM(:,:nCells) = MtoCM*velocityMeridional(:,:nCells)
+     uw_sfcCM(:iCell) = MtoCM*MtoCM*uw_sfc(:nCells)
+     vw_sfcCM(:iCell) = MtoCM*MtoCM*vw_sfc(:nCells)
+     wt_sfcCM(:iCell) = MtoCM*wt_sfc(:nCells)
+     ws_sfcCM(:iCell) = MtoCM*ws_sfc(:nCells)
+     dThreshMLDCM(:iCell) = MtoCM*dThreshMLD(:nCells)
+
+     call compute_ADC_tends(local_nCells, nVertLevels, ntracers, dt, activeTracers, velocityZonalCM, velocityMeridionalCM, &
+         BruntVaisalaFreqTop, uw_sfcCM, vw_sfcCM, wt_sfcCM, ws_sfcCM, inSituThermalExpansionCoeff,        &
+          inSituSalineContractionCoeff, fCell, dThreshMLDCM)
+
+     velocityZonal(:,:nCells) = velocityZonalCM(:,:nCells)/MtoCM
+     velocityMeridional(:,:nCells) = velocityMeridionalCM(:,:nCells)/MtoCM
 
      utend(:,:nCells) = (velocityZonal(:,:nCells) - utend(:,:nCells)) / dt
      vtend(:,:nCells) = (velocityMeridional(:,:nCells) - vtend(:,:nCells)) / dt

--- a/src/core_ocean/shared/mpas_ocn_vmix_adc.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_adc.F
@@ -142,8 +142,7 @@ contains
         normalVelocity, layerThickness, velocityZonal, velocityMeridional, &
         tracerGroupSurfaceFlux, tracerGroupSurfaceFluxRunoff, &
         tracerGroupSurfaceFluxRemoved, BruntVaisalaFreqTop,  &
-        inSituThermalExpansionCoeff, inSituSalineContractionCoeff, &
-        velocityZonalCM, velocityMeridionalCM
+        inSituThermalExpansionCoeff, inSituSalineContractionCoeff
 
       real (kind=RKIND), dimension(:,:,:), pointer :: activeTracers
       integer, pointer :: indexTemperature, indexSalinity
@@ -154,15 +153,12 @@ contains
       integer, dimension(:), pointer :: nCellsArray, nEdgesArray
       integer, dimension(:,:), pointer :: cellsOnEdge
      real (kind=RKIND), dimension(:), allocatable :: zonalAverage, meridionalAverage, uw_sfc, &
-                           vw_sfc, ws_sfc, wt_sfc, uw_sfcCM, vw_sfcCM, ws_sfcCM, wt_sfcCM, &
-                           dThreshMLDCM
+                           vw_sfc, ws_sfc, wt_sfc
 
       real (kind=RKIND), dimension(:,:), allocatable :: utend, vtend, ttend, stend
       real (kind=RKIND) :: fac, dep1, dep2, fracAbsorbed, fracAbsorbedRunoff,  &
                            etime
 
-      real (kind=RKIND) :: MtoCM, KGtoG
-                           
       !-----------------------------------------------------------------
       !
       ! call relevant routines for computing mixing-related fields
@@ -175,12 +171,6 @@ contains
       ! assume no errors during initialization and set to 1 when error is encountered
       !
       err=0
-
-      if (config_adc_convert_to_CGS) then
-         MtoCM = 1000.0_RKIND
-      else
-         MtoCM = 1.0_RKIND
-      endif
 
       if (present(timeLevelIn)) then
          timeLevel = timeLevelIn
@@ -248,11 +238,8 @@ contains
       nEdges = nEdgesArray( 3 )
 
       allocate(uw_sfc(nCells), vw_sfc(nCells), ws_sfc(nCells), wt_sfc(nCells))
-      allocate(uw_sfcCM(nCells), vw_sfcCM(nCells), ws_sfcCM(nCells), wt_sfcCM(nCells))
-      allocate(dThreshMLDCM(nCells))
       allocate(utend(nVertLevels,nCells), vtend(nVertLevels,nCells))
       allocate(ttend(nVertLevels,nCells), stend(nVertLevels,nCells))
-      allocate(velocityZonalCM(nVertLevels,nCells), velocityMeridionalCM(nVertLevels,nCells))
 
       !$omp do schedule(runtime)
       do iEdge=1,nEdges
@@ -316,13 +303,13 @@ contains
          vw_sfc(iCell) = stressMeridional(iCell) / rho_sw
 
          ze(1,iCell) = 0.0_RKIND
-         zm(1,iCell) = -MtoCM*layerThickness(1,iCell)/2.0_RKIND
+         zm(1,iCell) = -layerThickness(1,iCell)/2.0_RKIND
          do k=2,maxLevelCell(iCell)
-            ze(k,iCell) = ze(k-1,iCell) - MtoCM*layerThickness(k-1,iCell)
-            zm(k,iCell) = ze(k, iCell) - MtoCM*layerThickness(k,iCell)/2.0_RKIND
+            ze(k,iCell) = ze(k-1,iCell) - layerThickness(k-1,iCell)
+            zm(k,iCell) = ze(k, iCell) - layerThickness(k,iCell)/2.0_RKIND
          enddo
          k = maxLevelCell(iCell)+1
-         ze(k,iCell) = ze(k-1,iCell) - MtoCM*layerThickness(k-1,iCell)
+         ze(k,iCell) = ze(k-1,iCell) - layerThickness(k-1,iCell)
          do k = maxLevelCell(iCell) + 1, nVertLevels
             ze(k+1,iCell) = ze(maxLevelCell(iCell)+1,iCell)
             zm(k,iCell) = ze(maxLevelCell(iCell)+1,iCell)
@@ -345,20 +332,9 @@ contains
      ttend(:,:nCells) = activeTracers(1,:,:nCells)
      stend(:,:nCells) = activeTracers(2,:,:nCells)
 
-     velocityZonalCM(:,:nCells) = MtoCM*velocityZonal(:,:nCells)
-     velocityMeridionalCM(:,:nCells) = MtoCM*velocityMeridional(:,:nCells)
-     uw_sfcCM(:iCell) = MtoCM*MtoCM*uw_sfc(:nCells)
-     vw_sfcCM(:iCell) = MtoCM*MtoCM*vw_sfc(:nCells)
-     wt_sfcCM(:iCell) = MtoCM*wt_sfc(:nCells)
-     ws_sfcCM(:iCell) = MtoCM*ws_sfc(:nCells)
-     dThreshMLDCM(:iCell) = MtoCM*dThreshMLD(:nCells)
-
-     call compute_ADC_tends(local_nCells, nVertLevels, ntracers, dt, activeTracers, velocityZonalCM, velocityMeridionalCM, &
-         BruntVaisalaFreqTop, uw_sfcCM, vw_sfcCM, wt_sfcCM, ws_sfcCM, inSituThermalExpansionCoeff,        &
-          inSituSalineContractionCoeff, fCell, dThreshMLDCM)
-
-     velocityZonal(:,:nCells) = velocityZonalCM(:,:nCells)/MtoCM
-     velocityMeridional(:,:nCells) = velocityMeridionalCM(:,:nCells)/MtoCM
+     call compute_ADC_tends(local_nCells, nVertLevels, ntracers, dt, activeTracers, velocityZonal, velocityMeridional, &
+         BruntVaisalaFreqTop, uw_sfc, vw_sfc, wt_sfc, ws_sfc, inSituThermalExpansionCoeff,        &
+          inSituSalineContractionCoeff, fCell, dThreshMLD)
 
      utend(:,:nCells) = (velocityZonal(:,:nCells) - utend(:,:nCells)) / dt
      vtend(:,:nCells) = (velocityMeridional(:,:nCells) - vtend(:,:nCells)) / dt

--- a/src/core_ocean/shared/mpas_ocn_vmix_adc.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_adc.F
@@ -291,8 +291,8 @@ contains
                         activeTracers(indexTemperature,1,iCell) + tracerGroupSurfaceFluxRunoff(indexTemperature,iCell) * &
                         fracAbsorbedRunoff)
 
-         ws_sfc(iCell) = tracerGroupSurfaceFlux(indexSalinity, iCell) - fracAbsorbed * surfaceThicknessFlux(iCell) *  &
-                        activeTracers(indexSalinity,1,iCell)
+         ws_sfc(iCell) = -(tracerGroupSurfaceFlux(indexSalinity, iCell) - fracAbsorbed * surfaceThicknessFlux(iCell) *  &
+                        activeTracers(indexSalinity,1,iCell))
 
          uw_sfc(iCell) = stressZonal(iCell) / rho_sw
 


### PR DESCRIPTION
First part of this PR is just cleaning up some parts of the code that don't appear to be used anymore, reformatting, etc for clarity moving forward. If something critical was deleted/changed, let me know. Testing showed that this part of the PR did not change anything, as it shouldn't.

Second part of this PR is a cleaned up version of @vanroekel's tendency truncation commits in the ocean/adcTestBranch. I've added ability to turn on/off the truncation as well. Testing showed that with this feature turned off, nothing changes. With it on, with truncation set to 1.0E12, we can get BFB agreement between different decompositions of the budget terms (discussed in issue #18).

Third part of this PR is the ability to calculate everything within the ADC closure in units of centimeter-grams-seconds, instead of meter-kilograms-seconds. Testing shows that with this feature turned off, nothing changes. With it turned on, minor differences appear (as might be expected), but overall the answer is pretty much the same. Unfortunately, as it was hoped for, this does not fix the issue discussed in #18... unless you also pair it with the tendency truncation... so I am not sure that we want to keep this feature, given that it does not solve the issue it was implemented for. Let's discuss and decide...


