### PR TITLE
Adds commenting for the tendency terms

### DIFF
--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -275,7 +275,7 @@
 </var_struct>
 <var_struct name="adcTendArrays" time_levs="1" packages="adcMixingPKG">
   <var name="w2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="entrainment term -- similar to dissipation"
+       description="entrainment/detrainment term -- similar to dissipation"
        />
   <var name="w2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="turbulent transport of w2 [ -d(www)/dz ]"
@@ -293,7 +293,7 @@
        description="conversion of w2 to u2/v2 due to splat effects"
        />
   <var name="w3tend1" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-       description="entrainment and detrainment between plumes"
+       description="entrainment/detrainment term -- similar to dissipation"
        />
   <var name="w3tend2" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
        description="turbulent transport of w3 [ -d(w^4)/dz ]"
@@ -310,40 +310,40 @@
   <var name="w3tend6" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
        description="destruction due to splat effects"
        />
-  <var name="wttend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="entrainment term -- similar to dissipation"
+  <var name="wttend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
+       description="entrainment/detrainment term -- similar to dissipation"
        />
-  <var name="wttend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wttend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
        description="turbulent transport of wt [ -d(wtw)/dz ]"
        />
-  <var name="wttend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wttend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
        description="parameterized pressure-scalar terms (Rotta, rapid, buoyancy, Stokes)"
        />
-  <var name="wttend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wttend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
        description="gradient and buoyancy production term [ -w2*dT/dz + t*buoyancy]"
        />
-  <var name="wttend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wttend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
        description="dissipation of wt [ -kappa_FL*[d(wt)/dz]^2 ]"
        />
-  <var name="wttend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wttend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
        description="subplume scale production term"
        />
-  <var name="wstend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="entrainment term -- similar to dissipation"
+  <var name="wstend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
+       description="entrainment/detrainment term -- similar to dissipation"
        />
-  <var name="wstend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wstend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
        description="turbulent transport of ws [ -d(wsw)/dz ]"
        />
-  <var name="wstend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wstend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
        description="parameterized pressure-scalar terms (Rotta, rapid, buoyancy, Stokes)"
        />
-  <var name="wstend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wstend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
        description="gradient and buoyancy production term [ -w2*dS/dz + s*buoyancy]"
        />
-  <var name="wstend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wstend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
        description="dissipation of ws [ -kappa_FL*[d(ws)/dz]^2 ]"
        />
-  <var name="wstend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+  <var name="wstend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
        description="subplume scale production term"
        />
   <var name="uwtend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"

--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -299,7 +299,7 @@
        description="turbulent transport of w3 [ -d(w^4)/dz ]"
        />
   <var name="w3tend3" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-       description="gradient production of w3 [ (3/2)*w2*d(w2)/dz ]"
+       description="gradient production of w3 [ (3/2)*d( [w2]^2 )/dz ]"
        />
   <var name="w3tend4" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
        description="parameterized pressure terms (Rotta, buoyancy)"

--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -275,142 +275,142 @@
 </var_struct>
 <var_struct name="adcTendArrays" time_levs="1" packages="adcMixingPKG">
   <var name="w2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="entrainment production term -- similar to dissipation"
+       description="entrainment term -- similar to dissipation"
        />
   <var name="w2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="third order moment term (d / dz w^3)"
+       description="turbulent transport of w2 [ -d(www)/dz ]"
        />
   <var name="w2tend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="return to isotropy term"
+       description="parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)"
        />
   <var name="w2tend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="buoyancy production term"
        />
   <var name="w2tend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="shear production term"
+       description="sub-plume scale tendency term for w2"
        />
   <var name="w2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="conversion of w2 due to splat effects"
+       description="conversion of w2 to u2/v2 due to splat effects"
        />
   <var name="w3tend1" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-       description="entrainment production term -- similar to dissipation"
+       description="entrainment and detrainment between plumes"
        />
   <var name="w3tend2" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-       description="fourth order moment term (d / dz w^4)"
+       description="turbulent transport of w3 [ -d(w^4)/dz ]"
        />
   <var name="w3tend3" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-       description="w2 d/dz w2"
+       description="gradient production of w3 [ (3/2)*w2*d(w2)/dz ]"
        />
   <var name="w3tend4" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-       description="subplume terms + return to isotropy, latter dominates"
+       description="parameterized pressure terms (Rotta, buoyancy)"
        />
   <var name="w3tend5" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
-       description="third order moment of buoyancy, turb transport of buoyancy fluxes"
+       description="buoyancy production and sub-plume scale effects"
        />
   <var name="w3tend6" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
        description="destruction due to splat effects"
        />
   <var name="wttend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="divergence of turbulent transport of flux"
+       description="entrainment term -- similar to dissipation"
        />
   <var name="wttend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="gradient production w^2 dTdz"
+       description="turbulent transport of wt [ -d(wtw)/dz ]"
        />
   <var name="wttend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="buoyancy term"
+       description="parameterized pressure-scalar terms (Rotta, rapid, buoyancy, Stokes)"
        />
   <var name="wttend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="return to isotropy"
+       description="gradient and buoyancy production term [ -w2*dT/dz + t*buoyancy]"
        />
   <var name="wttend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="shear production term"
+       description="dissipation of wt [ -kappa_FL*[d(wt)/dz]^2 ]"
        />
   <var name="wttend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="subplume scale production term"
        />
   <var name="wstend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="divergence of turbulent transport of flux"
+       description="entrainment term -- similar to dissipation"
        />
   <var name="wstend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="gradient production w^2 dTdz"
+       description="turbulent transport of ws [ -d(wsw)/dz ]"
        />
   <var name="wstend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="buoyancy term"
+       description="parameterized pressure-scalar terms (Rotta, rapid, buoyancy, Stokes)"
        />
   <var name="wstend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="return to isotropy"
+       description="gradient and buoyancy production term [ -w2*dS/dz + s*buoyancy]"
        />
   <var name="wstend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="shear production term"
+       description="dissipation of ws [ -kappa_FL*[d(ws)/dz]^2 ]"
        />
   <var name="wstend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="subplume scale production term"
        />
   <var name="uwtend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="divergence of turbulent transport of flux"
+       description="turbulent transport of uw [ -d(uww)/dz ]"
        />
   <var name="uwtend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="gradient production "
+       description="parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)"
        />
   <var name="uwtend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="uv covariance"
+       description="shear production of uw [-w2*dU/dz]"
        />
   <var name="uwtend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="horizontal buoyancy flux term"
+       description="buoyancy production of uw (u*buoyancy)"
        />
   <var name="uwtend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="return to isotropy"
+       description="dissipation of uw [-kappa_FL*[d(uw)/dz]^2] "
        />
   <var name="vwtend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="divergence of turbulent transport of flux"
+       description="turbulent transport of vw [ -d(vww)/dz ]"
        />
   <var name="vwtend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="gradient production "
+       description="parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)"
        />
   <var name="vwtend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="uv covariance"
+       description="shear production of vw [-w2*dV/dz]"
        />
   <var name="vwtend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="horizontal buoyancy flux term"
+       description="buoyancy production of vw (v*buoyancy)"
        />
   <var name="vwtend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="return to isotropy"
+       description="dissipation of uw [-kappa_FL*[d(uw)/dz]^2]"
        />
   <var name="u2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="divergence of turbulent transport of flux"
+       description="turbulent transport of u2 [ -d(uuw)/dz ]"
        />
   <var name="u2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="gradient production proportional to dUdz"
+       description="parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)"
        />
   <var name="u2tend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="gradient production proportional to dVdz"
+       description="shear production of u2 [-2*uw*dU/dz]"
        />
   <var name="u2tend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="buoyancy production"
+       description="dummy variable (should be zero)"
        />
   <var name="u2tend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="return to isotropy"
+       description="dissipation of u2 [-(2/3)*dissipation]"
        />
   <var name="u2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="production due to splatting of w'2"
+       description="production due to splatting of w2"
        />
   <var name="v2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="divergence of turbulent transport of flux"
+       description="turbulent transport of v2 [ -d(vvw)/dz ]"
        />
   <var name="v2tend2" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="gradient production proportional to dUdz"
+       description="parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)"
        />
   <var name="v2tend3" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="gradient production proportional to dVdz"
+       description="shear production of v2 [-2*vw*dV/dz]"
        />
   <var name="v2tend4" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="buoyancy production"
+       description="dummy variable (should be zero)"
        />
   <var name="v2tend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="return to isotropy"
+       description="dissipation of v2 [-(2/3)*dissipation]"
        />
   <var name="v2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
-       description="production due to splatting of w'2"
+       description="production due to splatting of w2"
        />
   <var name="u2cliptend" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="if less than zero, it is reset to zero, this stores when that is active"
@@ -585,6 +585,7 @@
     <var name="w2tend3"/>
     <var name="w2tend4"/>
     <var name="w2tend5"/>
+    <var name="w2tend6"/>
     <var name="u2tend1"/>
     <var name="u2tend2"/>
     <var name="u2tend3"/>

--- a/src/core_ocean/adc_mixing/mpas_ocn_turbulence.F
+++ b/src/core_ocean/adc_mixing/mpas_ocn_turbulence.F
@@ -17,7 +17,7 @@
 !!  \date   14 Jan 2020
 !!  \details
 !!  This module creates and maintains a primary ocean mesh structure
-!!  for the ADC mixing scheme.  Eventually it will send arrays over to GPU 
+!!  for the ADC mixing scheme.  Eventually it will send arrays over to GPU
 !!  but for now just loads on to cpu
 !
 !-------------------------------------------------------------------------------
@@ -54,7 +54,7 @@ module ocn_turbulence
                        Detrainment, tumd, sumd, wumd, Mc
 
    real(kind=RKIND), dimension(:,:), pointer :: w2tend1, w2tend2,     &
-                       w2tend3, w2tend4, w2tend5, wttend1, wttend2,   &
+                       w2tend3, w2tend4, w2tend5, w2tend6, wttend1, wttend2,   &
                        wttend3, wttend4, wttend5, w3tend1, w3tend2,   &
                        w3tend3, w3tend5, w3tend4, wstend1, wstend2,   &
                        wstend3, wstend4, wstend5, uwtend1, uwtend2,   &
@@ -104,7 +104,8 @@ module ocn_turbulence
                        DetrainmentTmp, tumdTmp, sumdTmp, wumdTmp, McTmp
 
    real(kind=RKIND), dimension(:,:), pointer :: w2tend1Tmp, w2tend2Tmp,     &
-                       w2tend3Tmp, w2tend4Tmp, w2tend5Tmp, wttend1Tmp, wttend2Tmp,   &
+                       w2tend3Tmp, w2tend4Tmp, w2tend5Tmp, w2tend6Tmp, &
+                       wttend1Tmp, wttend2Tmp,   &
                        wttend3Tmp, wttend4Tmp, wttend5Tmp, w3tend1Tmp, w3tend2Tmp,   &
                        w3tend3Tmp, w3tend5Tmp, w3tend4Tmp, wstend1Tmp, wstend2Tmp,   &
                        wstend3Tmp, wstend4Tmp, wstend5Tmp, uwtend1Tmp, uwtend2Tmp,   &
@@ -231,6 +232,7 @@ module ocn_turbulence
       call mpas_pool_get_array(adcTendPool, 'w2tend3', w2tend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend4', w2tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend5', w2tend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'w2tend6', w2tend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend1', w3tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend2', w3tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend3', w3tend3Tmp)
@@ -275,6 +277,7 @@ module ocn_turbulence
       adcMixing%w2tend3 = w2tend3Tmp
       adcMixing%w2tend4 = w2tend4Tmp
       adcMixing%w2tend5 = w2tend5Tmp
+      adcMixing%w2tend6 = w2tend6Tmp
       adcMixing%w3tend1 = w3tend1Tmp
       adcMixing%w3tend2 = w3tend2Tmp
       adcMixing%w3tend3 = w3tend3Tmp

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -750,7 +750,7 @@ module ocn_adc_mixing_fused
 !                   (3) shear production of uv [uw*dV/dz + vw*dU/dz]
 !                   (4) dissipation of uv [ -kappa_FL*[d(uv)/dz]^2 ]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
-                uvtend(i3_f,k,iCell) = -(uvw(k-1,iCell) - uvw(k,iCell)) / dzmid & ! transport
+                uvtend(i3_f,k,iCell) = -(uvw(k-1,iCell) - uvw(k,iCell)) / dz & ! transport
                    - tauVel(k,iCell)*uv(i1,k,iCell)  & ! Rotta
                    - 0.5_RKIND*(alpha_1+alpha_2)*(uw(i1,k,iCell)*Vz &
                    + vw(i1,k,iCell)*Uz) + & ! rapid
@@ -841,12 +841,13 @@ module ocn_adc_mixing_fused
 !      The ut tendency is the sum of
 !                   (1) turbulent transport of ut [ -d(uwt)/dz ]
 !                   (2) parameterized pressure-strain terms (Rotta, rapid, Stokes)
-!                   (3) gradient production of ut [uw*dT/dz]
+!                   (3) shear production of ut [-wt*dU/dz]
+!                   (4) gradient production of ut [-uw*dT/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
-                 uttend(i3_f,k,iCell) = (-(uwt(k-1,iCell) - uwt(k,iCell))/dz  & ! Transport
+                 uttend(i3_f,k,iCell) = -(uwt(k-1,iCell) - uwt(k,iCell))/dz  & ! Transport
                    - ut(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
-                   - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 &
-                   + alpha_tracer2))*wt(i1,k,iCell)*Uz) & ! Rapid
+                   + 0.5_RKIND*(alpha_tracer1 + alpha_tracer2)*wt(i1,k,iCell)*Uz & ! Rapid
+                   - wt(i1,k,iCell)*Uz & ! Rapid
                    - uw(i1,k,iCell)*Tz ! Gradient production
 
                  if (config_adc_truncate_tend) then
@@ -859,12 +860,13 @@ module ocn_adc_mixing_fused
 !      The vt tendency is the sum of
 !                   (1) turbulent transport of vt [ -d(vwt)/dz ]
 !                   (2) parameterized pressure-strain terms (Rotta, rapid, Stokes)
-!                   (3) gradient production of vt [vw*dT/dz]
+!                   (3) shear production of vt [-wt*dV/dz]
+!                   (4) gradient production of vt [-vw*dT/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
-                 vttend(i3_f,k,iCell) = (-(vwt(k-1,iCell) - vwt(k,iCell))/dz  & ! Transport
+                 vttend(i3_f,k,iCell) = -(vwt(k-1,iCell) - vwt(k,iCell))/dz  & ! Transport
                    - vt(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
-                   - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 &
-                   + alpha_tracer2))*wt(i1,k,iCell)*Vz) & ! Rapid
+                   + 0.5_RKIND*(alpha_tracer1 + alpha_tracer2)*wt(i1,k,iCell)*Vz & ! Rapid
+                   - wt(i1,k,iCell)*Vz & ! Rapid
                    - vw(i1,k,iCell)*Tz ! Gradient production
 
                  if (config_adc_truncate_tend) then
@@ -874,14 +876,15 @@ module ocn_adc_mixing_fused
 
 !      CALCULATE US TENDENCY TERMS (these are not saved individually)
 !      The us tendency is the sum of
-!                   (1) turbulent transport of ut [ -d(uws)/dz ]
+!                   (1) turbulent transport of us [ -d(uws)/dz ]
 !                   (2) parameterized pressure-strain terms (Rotta, rapid, Stokes)
-!                   (3) gradient production of ut [uw*dS/dz]
+!                   (3) shear production of us [-ws*dU/dz]
+!                   (4) gradient production of us [-uw*dS/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
-                 ustend(i3_f,k,iCell) = (-(uws(k-1,iCell) - uws(k,iCell))/dz  & ! Transport
+                 ustend(i3_f,k,iCell) = -(uws(k-1,iCell) - uws(k,iCell))/dz  & ! Transport
                    - us(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
-                   - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 &
-                   + alpha_tracer2))*ws(i1,k,iCell)*Uz) & ! Rapid
+                   + 0.5_RKIND*(alpha_tracer1 + alpha_tracer2)*ws(i1,k,iCell)*Uz & ! Rapid
+                   - ws(i1,k,iCell)*Uz & ! Shear production
                    - uw(i1,k,iCell)*Sz ! Gradient production
 
                  if (config_adc_truncate_tend) then
@@ -890,16 +893,17 @@ module ocn_adc_mixing_fused
                  endif
 
 
-!      CALCULATE VT TENDENCY TERMS
+!      CALCULATE VS TENDENCY TERMS
 !      The vs tendency is the sum of the following terms (which are NOT saved individually)
 !                   (1) turbulent transport of vs [ -d(vws)/dz ]
 !                   (2) parameterized pressure-strain terms (Rotta, rapid, Stokes)
-!                   (3) gradient production of vs [vw*dS/dz]
+!                   (3) shear production of vs [-ws*dV/dz]
+!                   (4) gradient production of vs [-vw*dS/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
-                 vstend(i3_f,k,iCell) = (-(vws(k-1,iCell) - vws(k,iCell))/dz  & ! Transport
+                 vstend(i3_f,k,iCell) = -(vws(k-1,iCell) - vws(k,iCell))/dz  & ! Transport
                    - vs(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
-                   - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 &
-                   + alpha_tracer2))*ws(i1,k,iCell)*Vz) & ! Rapid
+                   + 0.5_RKIND*(alpha_tracer1 + alpha_tracer2)*ws(i1,k,iCell)*Vz & ! Rapid
+                   - ws(i1,k,iCell)*Vz & ! Rapid
                    - vw(i1,k,iCell)*Sz ! Gradient production
 
                  if (config_adc_truncate_tend) then

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -431,7 +431,7 @@ module ocn_adc_mixing_fused
 !      The w3 tendency is the sum of the following terms (saved individually)
 !                   (1) entrainment and detrainment between plumes
 !                   (2) turbulent transport of w3 [ -d(w^4)/dz ] where w^4 is estimated using ADC
-!                   (3) gradient production of w3 [ (3/2)*w2*d(w2)/dz ]
+!                   (3) gradient production of w3 [ (3/2)*d( [w2]^2 )/dz ]
 !                   (4) parameterized pressure terms (Rotta, buoyancy)
 !                   (5) buoyancy production and sub-plume scale effects
 !                   (6) splatting (calculated earlier)

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -752,10 +752,10 @@ module ocn_adc_mixing_fused
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
                 uvtend(i3_f,k,iCell) = -(uvw(k-1,iCell) - uvw(k,iCell)) / dz & ! transport
                    - tauVel(k,iCell)*uv(i1,k,iCell)  & ! Rotta
-                   - 0.5_RKIND*(alpha_1+alpha_2)*(uw(i1,k,iCell)*Vz &
-                   + vw(i1,k,iCell)*Uz) + & ! rapid
-                   (uw(i1,k,iCell)*Vz + vw(i1,k,iCell)*Uz) + & ! shear production
-                   kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) / &
+                   + 0.5_RKIND*(alpha_1+alpha_2)* &
+                   (uw(i1,k,iCell)*Vz + vw(i1,k,iCell)*Uz) & ! rapid
+                   - (uw(i1,k,iCell)*Vz + vw(i1,k,iCell)*Uz) & ! shear production
+                   + kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND ! dissipation
 
 !      Truncate the uv tendency term if the truncation flag is switched on

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -639,12 +639,11 @@ module ocn_adc_mixing_fused
                    areaFraction(k+1,iCell))*wumd(k+1,iCell)*sumd(k+1,iCell)*Mc(k+1,iCell)) &
                    / (ze(k-1,iCell) - ze(k+1,iCell))
 
-                 wstend3(k,iCell) = - tau_tracer(k,iCell)*ws(i1,k,iCell) + &
+                 wstend3(k,iCell) = - tau_tracer(k,iCell)*ws(i1,k,iCell) - &
                    C_b_tracer*grav*areaFraction(k,iCell)* &
                    (1.0_RKIND - areaFraction(k,iCell))*(alphaT(k,iCell) &
                    *tumd(k,iCell)*sumd(k,iCell) - betaS(k,iCell)*sumd(k,iCell)*sumd(k,iCell)) + &
-                   0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + &
-                   vs(i1,k,iCell)*Vz)
+                   0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + vs(i1,k,iCell)*Vz)
 
                  wstend4(k,iCell) = - Mc(k,iCell)*wumd(k,iCell)*Sz + &
                     grav*areaFraction(k,iCell)* &

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -420,22 +420,35 @@ module ocn_adc_mixing_fused
                  wumdav = wumdMid(k,ICell)
                  sigav = areaFractionMid(k,iCell)
                  Mcav = McMid(k,iCell)
-                 
+
+                SwU = -(1.0_RKIND-2.0_RKIND*areaFraction(k,iCell)) &
+                   /(areaFraction(k,iCell)*(1.0_RKIND-areaFraction(k,iCell)))**0.5_RKIND
+                SwD = -(1.0_RKIND-2.0_RKIND*areaFraction(k+1,iCell)) &
+                   /(areaFraction(k+1,iCell)*(1.0_RKIND-areaFraction(k+1,iCell)))**0.5_RKIND
+
+!      CALCULATE W3 TENDENCY TERMS
+!      Calculate the tendency (rate-of-change) terms for the w3 budget.
+!      The w3 tendency is the sum of the following terms (saved individually)
+!                   (1) entrainment and detrainment between plumes
+!                   (2) turbulent transport of w3 [ -d(w^4)/dz ] where w^4 is estimated using ADC
+!                   (3) gradient production of w3 [ (3/2)*w2*d(w2)/dz ]
+!                   (4) parameterized pressure terms (Rotta, buoyancy)
+!                   (5) buoyancy production and sub-plume scale effects
+!                   (6) splatting (calculated earlier)
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
                  w3tend1(k,iCell) = -wumdav**3.0_RKIND*(Eav*(3.0_RKIND*sigav - 2.0_RKIND) &
                    + Dav*(3.0_RKIND*sigav - 1.0_RKIND))
 
-                 SwU = -(1.0_RKIND-2.0_RKIND*areaFraction(k,iCell)) &
-                   /(areaFraction(k,iCell)*(1.0_RKIND-areaFraction(k,iCell)))**0.5_RKIND
-                 SwD = -(1.0_RKIND-2.0_RKIND*areaFraction(k+1,iCell)) &
-                   /(areaFraction(k+1,iCell)*(1.0_RKIND-areaFraction(k+1,iCell)))**0.5_RKIND
                  w3tend2(k,iCell) = -((3.0_RKIND + SwU**2.0_RKIND)*(w2(i1,k,iCell)**2.0_RKIND) - &
                    (3.0_RKIND + SwD**2.0_RKIND)*(w2(i1,k+1,iCell)**2.0_RKIND) ) / dz
+
                  w3tend3(k,iCell) = 1.5_RKIND*(w2(i1,k,iCell)**2.0_RKIND - w2(i1,k+1,iCell)**2.0_RKIND) / dz
 
-                 w3tend4(k,iCell) = -3.0_RKIND*(1.0_RKIND - 2.0_RKIND*sigav)*Mcav*wumdav*Swumd(k,iCell) - &
-                   tauw3(k,iCell)*w3(i1,k,iCell)
-                 w3tend5(k,iCell) = 3.0_RKIND*(1.0_RKIND - c11)*grav*(alphaT(k,iCell)*w2t(k,iCell) - &
-                   betaS(k,iCell)*w2s(k,iCell))
+                 w3tend4(k,iCell) = - tauw3(k,iCell)*w3(i1,k,iCell) - &
+                   3.0_RKIND*c11*grav*(alphaT(k,iCell)*w2t(k,iCell) - betaS(k,iCell)*w2s(k,iCell))
+
+                 w3tend5(k,iCell) = 3.0_RKIND*grav*(alphaT(k,iCell)*w2t(k,iCell) - betaS(k,iCell)* &
+                   w2s(k,iCell)) - 3.0_RKIND*(1.0_RKIND - 2.0_RKIND*sigav)*Mcav*wumdav*Swumd(k,iCell)
 
                  w3tend(i3_f,k,iCell) = w3tend1(k,iCell) + w3tend2(k,iCell) + w3tend3(k,iCell) + &
                    w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell)
@@ -450,7 +463,7 @@ module ocn_adc_mixing_fused
                       + 0.5_RKIND)) / adcRound
                  endif
 
-!     now get all the downgradient TOMs
+!     now get all the downgradient third-order moments
                  KE = 0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + w2(i1,k,iCell))
                  KEp1 = 0.5_RKIND*(u2(i1,k+1,iCell) + v2(i1,k+1,iCell) + w2(i1,k+1,iCell))
                  lenav = 0.5_RKIND*(length(k,iCell) + length(k+1,iCell))
@@ -493,37 +506,83 @@ module ocn_adc_mixing_fused
                  tauVel(k,iCell) = C_slow*KE / (1.0E-15_RKIND + length(k,iCell))
                  tauvVel(k,iCell) = slow_w_factor*C_slow*KE / (1.0E-15_RKIND + length(k,iCell))
 
+
+!      CALCULATE W2 TENDENCY TERMS
+!      Calculate the tendency (rate-of-change) terms for the w2 budget. These terms
+!      are separated based on the physical processes that cause each tendency term.
+!      The w2 tendency is the sum of the following terms (which are saved individually)
+!                   (1) entrainment and detrainment between plumes
+!                   (2) turbulent transport of w2 [ -d(www)/dz ]
+!                   (3) parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)
+!                   (4) production of w2 by buoyancy fluxes (conversion to/from potential energy)
+!                   (5) sub-plume scale effects (based on Lappen & Randall 2001)
+!                   (6) splatting (calculated earlier; converts w2 to u2/v2 near surface)
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+!      The parameterization consists of a slow (Rotta) term [Rotta, 1951],
+!      a rapid term that depends on gradients in mean velocity [Speziale et al., 1991],
+!      a buoyancy term [Umlauf & Burchard, 2005], and
+!      a Stokes drift term based on Pearson et al., 2019.
+!      Note that the slow pressure w2 term is included below so that w2tend3 an be compared directly to
+!      pressure-strain terms, but it is removed  as it is included implicitly in the timestepping
                  w2tend1(k,iCell) = -wumd(k,iCell)**2.0_RKIND*(         &
                    Entrainment(k,iCell) + Detrainment(k,iCell))
+
                  w2tend2(k,iCell) = (McMid(k-1,iCell)*(1.0_RKIND - 2.0_RKIND* &
                    areaFractionMid(k-1,iCell))*wumdMid(k-1,iCell)**2.0_RKIND - McMid(k,iCell)* &
                    (1.0_RKIND - 2.0_RKIND*areaFractionMid(k,iCell))*wumdMid(k,iCell)**2.0_RKIND) / dzmid
-                 w2tend3(k,iCell) = tauvVel(k,iCell)*(u2(i1,k,iCell) + v2(i1,k,iCell))/3.0_RKIND
-                 w2tend4(k,iCell) = (2.0_RKIND - 4.0_RKIND/3.0_RKIND*C_b)*Mc(k,iCell)* &
-                   (grav*alphaT(k,iCell)*tumd(k,iCell) - grav*betaS(k,iCell)*sumd(k,iCell))
-                 w2tend5(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 -            &
-                   alpha_2)*(uw(i1,k,iCell)*Uz + vw(i1,k,iCell)*Vz) +         &
-                   Mc(k,iCell)*(Swumd(k-1,iCell) + Swumd(k,iCell))
 
+                 w2tend3(k,iCell) = tauvVel(k,iCell)*(u2(i1,k,iCell) + v2(i1,k,iCell) &
+                 -2.0_RKIND*w2(i1,k,iCell))/3.0_RKIND + (1.0_RKIND/3.0_RKIND*alpha_1 - &
+                   alpha_2)*(uw(i1,k,iCell)*Uz + vw(i1,k,iCell)*Vz) - 4.0_RKIND/3.0_RKIND* &
+                   C_b*Mc(k,iCell)*(grav*alphaT(k,iCell)*tumd(k,iCell) - &
+                   grav*betaS(k,iCell)*sumd(k,iCell))
+
+                 w2tend4(k,iCell) = 2.0_RKIND*Mc(k,iCell)* &
+                   (grav*alphaT(k,iCell)*tumd(k,iCell) - grav*betaS(k,iCell)*sumd(k,iCell))
+
+                 w2tend5(k,iCell) = Mc(k,iCell)*(Swumd(k-1,iCell) + Swumd(k,iCell))
+!      Sum the above tendency terms to find the total w2 tendency.
+!      Note this includes a splatting term calculated earlier (w2tend6).
+!      Also, the w2 slow pressure term (within w2tend3) is removed here as it is
+!      included implicitly in the timestepping
                  w2tend(i3_f,k,iCell) = w2tend1(k,iCell) + w2tend2(k,iCell) + &
-                   w2tend3(k,iCell) + w2tend4(k,iCell) + w2tend5(k,iCell) + w2tend6(k,iCell)
+                   w2tend3(k,iCell) + w2tend4(k,iCell) + w2tend5(k,iCell) + &
+                   w2tend6(k,iCell) + 2.0_RKIND*tauvVel(k,iCell)*w2(i1,k,iCell)/3.0_RKIND
 
                  if (config_adc_truncate_tend) then
                     w2tend(i3_f,k,iCell) = FLOAT (INT(w2tend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
 
+
+!      CALCULATE WT TENDENCY TERMS
+!      The wt tendency is the sum of the following terms (which are saved individually)
+!                   (1) entrainment and detrainment between plumes
+!                   (2) turbulent transport of wt [ -d(wtw)/dz ]
+!                   (3) parameterized pressure-scalar terms (Rotta, rapid, buoyancy, Stokes)
+!                   (4) gradient and buoyancy production terms of wt [ -w2*dT/dz + t*buoyancy]
+!                   (5) dissipation of wt [ -kappa_FL*[d(wt)/dz]^2 ]
+!                   (6) sub-plume scale effects (based on Lappen & Randall 2001)
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
                  wttend1(k,iCell) = -1.0_RKIND*(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
                    wumd(k,iCell)*tumd(k,iCell)
-                 wttend2(k,iCell) = -(w2t(k-1,iCell) - w2t(k,iCell)) / (zm(k-1,iCell) - zm(k,iCell)) - &
-                   Mc(k,iCell)*wumd(k,iCell)*Tz*0.0_RKIND
-                 wttend3(k,iCell) = (1.0_RKIND - C_b_tracer)*areaFraction(k,iCell)*  &
+
+                 wttend2(k,iCell) = -(w2t(k-1,iCell) - w2t(k,iCell)) / (zm(k-1,iCell) - zm(k,iCell))
+
+                 wttend3(k,iCell) = - tau_tracer(k,iCell)*wt(i1,k,iCell) &
+                    - C_b_tracer*areaFraction(k,iCell)*  &
                    (1.0_RKIND - areaFraction(k,iCell))*grav*(alphaT(k,iCell) &
+                   *tumd(k,iCell)**2.0_RKIND - betaS(k,iCell)*tumd(k,iCell)*sumd(k,iCell)) + &
+                   0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(ut(i1,k,iCell)*Uz + &
+                   vt(i1,k,iCell)*Vz)
+
+                 wttend4(k,iCell) = - Mc(k,iCell)*wumd(k,iCell)*Tz + &
+                   areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))*grav*(alphaT(k,iCell) &
                    *tumd(k,iCell)**2.0_RKIND - betaS(k,iCell)*tumd(k,iCell)*sumd(k,iCell))
-                 wttend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(ut(i1,k,iCell)*Uz + &
-                   vt(i1,k,iCell)*Vz) - Mc(k,iCell)*wumd(k,iCell)*Tz
+
                  wttend5(k,iCell) = kappa_FL*(wt(i1,k-1,iCell) -       &
                    wt(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
+
                  wttend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
                    tumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
                    (1.0_RKIND / areaFraction(k,iCell) * (areaFraction(k-1,iCell)*wt_spsU(k-1,iCell) - &
@@ -531,28 +590,51 @@ module ocn_adc_mixing_fused
                    -1.0_RKIND/(1.0_RKIND - areaFraction(k,iCell))*((1.0_RKIND - areaFraction(k-1,iCell))* &
                    wt_spsD(k-1,iCell) - (1.0_RKIND - areaFraction(k+1,iCell))*wt_spsD(k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell)))
-
+!      Sum the above tendency terms to find the total wt tendency.
+!      Also, the wt slow pressure term (within wttend3) is removed here as it is
+!      included implicitly in the timestepping
                  wttend(i3_f,k,iCell) = wttend1(k,iCell) + wttend2(k,iCell) +        &
-                   wttend3(k,iCell) + wttend4(k,iCell) + wttend5(k,iCell) + wttend6(k,iCell)
+                   wttend3(k,iCell) + wttend4(k,iCell) + wttend5(k,iCell) + wttend6(k,iCell) + &
+                   tau_tracer(k,iCell)*wt(i1,k,iCell)
 
                  if (config_adc_truncate_tend) then
                     wttend(i3_f,k,iCell) = FLOAT (INT(wttend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
 
+
+!      CALCULATE WS TENDENCY TERMS
+!      The ws tendency is the sum of the following terms (which are saved individually)
+!                   (1) entrainment and detrainment between plumes
+!                   (2) turbulent transport of ws [ -d(wsw)/dz ]
+!                   (3) parameterized pressure-scalar terms (Rotta, rapid, buoyancy, Stokes)
+!                   (4) gradient and buoyancy production terms of ws [ -w2*dS/dz + s*buoyancy]
+!                   (5) dissipation of ws [ -kappa_FL*[d(ws)/dz]^2 ]
+!                   (6) sub-plume scale effects (based on Lappen & Randall 2001)
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
                  wstend1(k,iCell) = -(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
                    wumd(k,iCell)*sumd(k,iCell)
+
                  wstend2(k,iCell) = ((1.0_RKIND - 2.0_RKIND*areaFraction(k-1,iCell))* &
                    wumd(k-1,iCell)*sumd(k-1,iCell)*Mc(k-1,iCell) - (1.0_RKIND - 2.0_RKIND* &
                    areaFraction(k+1,iCell))*wumd(k+1,iCell)*sumd(k+1,iCell)*Mc(k+1,iCell)) &
-                   / (ze(k-1,iCell) - ze(k+1,iCell)) - Mc(k,iCell)*wumd(k,iCell)*Sz
-                 wstend3(k,iCell) = (1.0_RKIND - C_b_tracer)*grav*areaFraction(k,iCell)* &
+                   / (ze(k-1,iCell) - ze(k+1,iCell))
+
+                 wstend3(k,iCell) = - tau_tracer(k,iCell)*ws(i1,k,iCell) + &
+                   C_b_tracer*grav*areaFraction(k,iCell)* &
+                   (1.0_RKIND - areaFraction(k,iCell))*(alphaT(k,iCell) &
+                   *tumd(k,iCell)*sumd(k,iCell) - betaS(k,iCell)*sumd(k,iCell)*sumd(k,iCell)) + &
+                   0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + &
+                   vs(i1,k,iCell)*Vz)
+
+                 wstend4(k,iCell) = - Mc(k,iCell)*wumd(k,iCell)*Sz + &
+                    grav*areaFraction(k,iCell)* &
                    (1.0_RKIND - areaFraction(k,iCell))*(alphaT(k,iCell) &
                    *tumd(k,iCell)*sumd(k,iCell) - betaS(k,iCell)*sumd(k,iCell)*sumd(k,iCell))
-                 wstend4(k,iCell) = 0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + &
-                   vs(i1,k,iCell)*Vz)
+
                  wstend5(k,iCell) = kappa_FL*(ws(i1,k-1,iCell) -       &
                    ws(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
+
                  wstend6(k,iCell) = areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))* &
                    sumd(k,iCell)*0.5_RKIND*(Swumd(k-1,iCell) + Swumd(k,iCell)) - Mc(k,iCell)* &
                    (1.0_RKIND / areaFraction(k,iCell) * (areaFraction(k-1,iCell)*ws_spsU(k-1,iCell) - &
@@ -560,27 +642,44 @@ module ocn_adc_mixing_fused
                    -1.0_RKIND/(1.0_RKIND - areaFraction(k,iCell))*((1.0_RKIND - areaFraction(k-1,iCell))* &
                    ws_spsD(k-1,iCell) - (1.0_RKIND - areaFraction(k+1,iCell))*ws_spsD(k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell)))
-
+!      Sum the above tendency terms to find the total ws tendency.
+!      Also, the ws slow pressure term (within wstend3) is removed here as it is
+!      included implicitly in the timestepping
                  wstend(i3_f,k,iCell) = wstend1(k,iCell) + wstend2(k,iCell) + &
-                   wstend3(k,iCell) + wstend4(k,iCell) + wstend5(k,iCell) + wstend6(k,iCell)
+                   wstend3(k,iCell) + wstend4(k,iCell) + wstend5(k,iCell) + wstend6(k,iCell) + &
+                   tau_tracer(k,iCell)*ws(i1,k,iCell)
 
                  if (config_adc_truncate_tend) then
                     wstend(i3_f,k,iCell) = FLOAT (INT(wstend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
 
-                 uwtend1(k,iCell) = -(uw2(k-1,iCell) - uw2(k,iCell)) / dzmid
-                 uwtend2(k,iCell) = 0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
-                   (alpha_1 - alpha_2)*u2(i1,k,iCell) + (alpha_1 +  &
-                   alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Uz
-                 uwtend3(k,iCell) = 0.5_RKIND*(alpha_1 - alpha_2)*    &
-                   uv(i1,k,iCell)*Vz
-                 uwtend4(k,iCell) = (1-C_b)*grav*(alphaT(k,iCell)*   &
-                   ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell))
-                 uwtend5(k,iCell) = -tauVel(k,iCell)*uw(i1,k,iCell) + &
-                   kappa_FL*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
-                   (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
+!      CALCULATE UW TENDENCY TERMS
+!      The uw tendency is the sum of the following terms (which are saved individually)
+!                   (1) turbulent transport of uw [ -d(uww)/dz ]
+!                   (2) parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)
+!                   (3) shear production of uw [-w2*dU/dz]
+!                   (4) buoyancy production of uw [ u*buoyancy]
+!                   (5) dissipation of uw [ -kappa_FL*[d(uw)/dz]^2 ]
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+                 uwtend1(k,iCell) = -(uw2(k-1,iCell) - uw2(k,iCell)) / dzmid
+
+                 uwtend2(k,iCell) = -tauVel(k,iCell)*uw(i1,k,iCell) + &
+                   0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
+                   (alpha_1 - alpha_2)*u2(i1,k,iCell) + (alpha_1 +  &
+                   alpha_2)*w2(i1,k,iCell))*Uz + 0.5_RKIND*(alpha_1 - alpha_2)*    &
+                   uv(i1,k,iCell)*Vz - C_b*grav*(alphaT(k,iCell)*   &
+                   ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell))
+
+                 uwtend3(k,iCell) = - w2(i1,k,iCell)*Uz
+
+                 uwtend4(k,iCell) = grav*(alphaT(k,iCell)*   &
+                   ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell))
+
+                 uwtend5(k,iCell) = kappa_FL*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
+                   (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
+!      Sum the above tendency terms to find the total uw tendency.
                  uwtend(i3_f,k,iCell) = uwtend1(k,iCell) + uwtend2(k,iCell) + &
                    uwtend3(k,iCell) + uwtend4(k,iCell) + uwtend5(k,iCell)
 
@@ -589,100 +688,206 @@ module ocn_adc_mixing_fused
                       + 0.5_RKIND)) / adcRound
                  endif
 
-                 vwtend(i3_f,k,iCell) = (-(vw2(k-1,iCell) - vw2(k,iCell)) / dzmid  &
-                   + 0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
-                   (alpha_1 - alpha_2)*v2(i1,k,iCell) + (alpha_1 +   &
-                   alpha_2 - 2.0_RKIND)*w2(i1,k,iCell))*Vz + 0.5_RKIND*(alpha_1 &
-                   - alpha_2)*uv(i1,k,iCell)*Uz + (1-C_b)*grav*       &
-                   (alphaT(k,iCell)*vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))) -            &
-                   tauVel(k,iCell)*vw(i1,k,iCell) + kappa_FL*(vw(i1,k-1,iCell) &
-                   - vw(i1,k+1,iCell)) / (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
+
+!      CALCULATE VW TENDENCY TERMS
+!      The vw tendency is the sum of the following terms (which are saved individually)
+!                   (1) turbulent transport of vw [ -d(vww)/dz ]
+!                   (2) parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)
+!                   (3) shear production of vw [-w2*dV/dz]
+!                   (4) buoyancy production of vw [ v*buoyancy]
+!                   (5) dissipation of vw [ -kappa_FL*[d(vw)/dz]^2 ]
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+                 vwtend1(k,iCell) = -(vw2(k-1,iCell) - vw2(k,iCell)) / dzmid
+
+                 vwtend2(k,iCell) = -tauVel(k,iCell)*vw(i1,k,iCell) + &
+                   0.5_RKIND*((alpha_0 - 4.0_RKIND*alpha_1/3.0_RKIND)*KE**2.0_RKIND +  &
+                   (alpha_1 - alpha_2)*v2(i1,k,iCell) + (alpha_1 +  &
+                   alpha_2)*w2(i1,k,iCell))*Vz + 0.5_RKIND*(alpha_1 - alpha_2)*    &
+                   uv(i1,k,iCell)*Uz - C_b*grav*(alphaT(k,iCell)*   &
+                   vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))
+
+                 vwtend3(k,iCell) = - w2(i1,k,iCell)*Vz
+
+                 vwtend4(k,iCell) = grav*(alphaT(k,iCell)*   &
+                   vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))
+
+                 vwtend5(k,iCell) = kappa_FL*(vw(i1,k-1,iCell) - vw(i1,k+1,iCell)) / &
+                   (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
+!      Sum the above tendency terms to find the total vw tendency.
+                 vwtend(i3_f,k,iCell) = vwtend1(k,iCell) + vwtend2(k,iCell) + &
+                   vwtend3(k,iCell) + vwtend4(k,iCell) + vwtend5(k,iCell)
 
                  if (config_adc_truncate_tend) then
                     vwtend(i3_f,k,iCell) = FLOAT (INT(vwtend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
 
-                 uvtend(i3_f,k,iCell) = (-(uvw(k-1,iCell) - uvw(k,iCell)) / dz - &
-                   (1.0_RKIND - 0.5_RKIND*(alpha_1+alpha_2))*(uw(i1,k,iCell)*Vz &
-                   + vw(i1,k,iCell)*Uz)) - tauVel(k,iCell)*uv(i1,k,iCell) +           &
-                   kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) /       &
-                   (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
 
+!      CALCULATE UV TENDENCY TERMS (these are not saved individually)
+!      The uv tendency is the sum of
+!                   (1) turbulent transport of vw [ -d(vww)/dz ]
+!                   (2) parameterized pressure-strain terms (Rotta, rapid, Stokes)
+!                   (3) shear production of uv [uw*dV/dz + vw*dU/dz]
+!                   (4) dissipation of uv [ -kappa_FL*[d(uv)/dz]^2 ]
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+                uvtend(i3_f,k,iCell) = -(uvw(k-1,iCell) - uvw(k,iCell)) / dzmid & ! transport
+                   - tauVel(k,iCell)*uv(i1,k,iCell)  & ! Rotta
+                   - 0.5_RKIND*(alpha_1+alpha_2)*(uw(i1,k,iCell)*Vz &
+                   + vw(i1,k,iCell)*Uz) + & ! rapid
+                   (uw(i1,k,iCell)*Vz + vw(i1,k,iCell)*Uz) + & ! shear production
+                   kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) / &
+                   (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND ! dissipation
+
+!      Truncate the uv tendency term if the truncation flag is switched on
                  if (config_adc_truncate_tend) then
                     uvtend(i3_f,k,iCell) = FLOAT (INT(uvtend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
 
-                 u2tend1(k,iCell) = -(u2w(k-1,iCell) - u2w(k,iCell)) / dzmid
-                 u2tend2(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2 &
-                   -2.0_RKIND)*uw(i1,k,iCell)*Uz
-                 u2tend3(k,iCell) = - 2.0_RKIND/3.0_RKIND*alpha_1*vw(i1,k,iCell)*Vz
-                 u2tend4(k,iCell) = 2.0_RKIND/3.0_RKIND*C_b*B
-                 u2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell) + &
-                   tauVel(k,iCell)*(v2(i1,k,iCell) + areaFraction(k,iCell)* &
-                   (1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND
 
+!      CALCULATE U2 TENDENCY TERMS
+!      The u2 tendency is the sum of the following terms (which are saved individually)
+!                   (1) turbulent transport of u2 [ -d(uuw)/dz ]
+!                   (2) parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)
+!                   (3) shear production of u2 [-2*uw*dU/dz]
+!                   (4) dummy variable (should be zero)
+!                   (5) dissipation of u2 [-(2/3)*dissipation]
+!                   (6) splatting (calculated earlier)
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+                 u2tend1(k,iCell) = -(u2w(k-1,iCell) - u2w(k,iCell)) / dzmid
+
+                 u2tend2(k,iCell) = tauVel(k,iCell)*(v2(i1,k,iCell) - 2.0_RKIND* &
+                   u2(i1,k,iCell) + areaFraction(k,iCell)*(1.0_RKIND - &
+                   areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND + &
+                   (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2) &
+                   *uw(i1,k,iCell)*Uz - 2.0_RKIND/3.0_RKIND*alpha_1*vw(i1,k,iCell)*Vz &
+                   + 2.0_RKIND/3.0_RKIND*C_b*B
+
+                 u2tend3(k,iCell) = -2.0_RKIND*uw(i1,k,iCell)*Uz
+
+                 u2tend4(k,iCell) = 0.0_RKIND
+
+                 u2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell)
+!      Sum the above tendency terms to find the total u2 tendency.
+!      Note, the u2 slow pressure term (within u2tend3) is removed here as it is
+!      included implicitly in the timestepping
                  u2tend(i3_f,k,iCell) = u2tend1(k,iCell) + u2tend2(k,iCell) + &
-                   u2tend3(k,iCell) + u2tend4(k,iCell) + u2tend5(k,iCell) + u2tend6(k,iCell)
+                   u2tend3(k,iCell) + u2tend4(k,iCell) + u2tend5(k,iCell) + &
+                   u2tend6(k,iCell) + 2.0_RKIND*tauvVel(k,iCell)*u2(i1,k,iCell)/3.0_RKIND
 
                  if (config_adc_truncate_tend) then
                     u2tend(i3_f,k,iCell) = FLOAT (INT(u2tend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
-                
-                 v2tend1(k,iCell) = -(v2w(k-1,iCell) - v2w(k,iCell)) / dzmid
-                 v2tend2(k,iCell) = (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2 &
-                   - 2.0_RKIND)*vw(i1,k,iCell)*Vz
-                 v2tend3(k,iCell) = - 2.0_RKIND/3.0_RKIND*alpha_1*uw(i1,k,iCell)*Uz
-                 v2tend4(k,iCell) = 2.0_RKIND/3.0_RKIND*C_b*B
-                 v2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell) + &
-                   tauVel(k,iCell)*(u2(i1,k,iCell) + areaFraction(k,iCell)* &
-                   (1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND
 
+
+!      CALCULATE V2 TENDENCY TERMS
+!      The v2 tendency is the sum of the following terms (which are saved individually)
+!                   (1) turbulent transport of v2 [ -d(vvw)/dz ]
+!                   (2) parameterized pressure-strain terms (Rotta, rapid, buoyancy, Stokes)
+!                   (3) shear production of v2 [-2*vw*dV/dz]
+!                   (4) dummy variable (should be zero)
+!                   (5) dissipation of v2 [-(2/3)*dissipation]
+!                   (6) splatting (calculated earlier)
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+                 v2tend1(k,iCell) = -(v2w(k-1,iCell) - v2w(k,iCell)) / dzmid
+
+                 v2tend2(k,iCell) = tauVel(k,iCell)*(u2(i1,k,iCell) - 2.0_RKIND* &
+                   v2(i1,k,iCell) + areaFraction(k,iCell)*(1.0_RKIND - &
+                   areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND + &
+                   (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2) &
+                   *vw(i1,k,iCell)*Vz - 2.0_RKIND/3.0_RKIND*alpha_1*uw(i1,k,iCell)*Uz &
+                   + 2.0_RKIND/3.0_RKIND*C_b*B
+
+                 v2tend3(k,iCell) = -2.0_RKIND*vw(i1,k,iCell)*Vz
+
+                 v2tend4(k,iCell) = 0.0_RKIND
+
+                 v2tend5(k,iCell) = -2.0_RKIND/3.0_RKIND*eps(i1,k,iCell)
+!      Sum the above tendency terms to find the total v2 tendency.
+!      Note, the v2 slow pressure term (within v2tend3) is removed here as it is
+!      included implicitly in the timestepping
                  v2tend(i3_f,k,iCell) = v2tend1(k,iCell) + v2tend2(k,iCell) + &
-                   v2tend3(k,iCell) + v2tend4(k,iCell) + v2tend5(k,iCell) + v2tend6(k,iCell)
+                   v2tend3(k,iCell) + v2tend4(k,iCell) + v2tend5(k,iCell) + &
+                   v2tend6(k,iCell) + 2.0_RKIND*tauvVel(k,iCell)*v2(i1,k,iCell)/3.0_RKIND
 
                  if (config_adc_truncate_tend) then
                     v2tend(i3_f,k,iCell) = FLOAT (INT(v2tend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
+                
 
-                 uttend(i3_f,k,iCell) = (-(uwt(k-1,iCell) - uwt(k,iCell))/dz -  &
-                   uw(i1,k,iCell)*Tz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
-                   alpha_tracer2))*wt(i1,k,iCell)*Uz) - ut(i1,k,iCell)*tau_tracer(k,iCell)
+!      CALCULATE UT TENDENCY TERMS (these are not saved individually)
+!      The ut tendency is the sum of
+!                   (1) turbulent transport of ut [ -d(uwt)/dz ]
+!                   (2) parameterized pressure-strain terms (Rotta, rapid, Stokes)
+!                   (3) gradient production of ut [uw*dT/dz]
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+                 uttend(i3_f,k,iCell) = (-(uwt(k-1,iCell) - uwt(k,iCell))/dz  & ! Transport
+                   - ut(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
+                   - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 &
+                   + alpha_tracer2))*wt(i1,k,iCell)*Uz) & ! Rapid
+                   - uw(i1,k,iCell)*Tz ! Gradient production
 
                  if (config_adc_truncate_tend) then
                     uttend(i3_f,k,iCell) = FLOAT (INT(uttend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
 
-                 vttend(i3_f,k,iCell) = (-(vwt(k-1,iCell) - vwt(k,iCell))/dz -  &
-                   vw(i1,k,iCell)*Tz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
-                   alpha_tracer2))*wt(i1,k,iCell)*Vz) - vt(i1,k,iCell)*tau_tracer(k,iCell)
+
+!      CALCULATE VT TENDENCY TERMS (these are not saved individually)
+!      The vt tendency is the sum of
+!                   (1) turbulent transport of vt [ -d(vwt)/dz ]
+!                   (2) parameterized pressure-strain terms (Rotta, rapid, Stokes)
+!                   (3) gradient production of vt [vw*dT/dz]
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+                 vttend(i3_f,k,iCell) = (-(vwt(k-1,iCell) - vwt(k,iCell))/dz  & ! Transport
+                   - vt(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
+                   - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 &
+                   + alpha_tracer2))*wt(i1,k,iCell)*Vz) & ! Rapid
+                   - vw(i1,k,iCell)*Tz ! Gradient production
 
                  if (config_adc_truncate_tend) then
                     vttend(i3_f,k,iCell) = FLOAT (INT(vttend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
 
-                 ustend(i3_f,k,iCell) = (-(uws(k-1,iCell) - uws(k,iCell))/dz -  &
-                   uw(i1,k,iCell)*Sz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
-                   alpha_tracer2))*ws(i1,k,iCell)*Uz) - us(i1,k,iCell)*tau_tracer(k,ICell)
-                 
+!      CALCULATE US TENDENCY TERMS (these are not saved individually)
+!      The us tendency is the sum of
+!                   (1) turbulent transport of ut [ -d(uws)/dz ]
+!                   (2) parameterized pressure-strain terms (Rotta, rapid, Stokes)
+!                   (3) gradient production of ut [uw*dS/dz]
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+                 ustend(i3_f,k,iCell) = (-(uws(k-1,iCell) - uws(k,iCell))/dz  & ! Transport
+                   - us(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
+                   - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 &
+                   + alpha_tracer2))*ws(i1,k,iCell)*Uz) & ! Rapid
+                   - uw(i1,k,iCell)*Sz ! Gradient production
+
                  if (config_adc_truncate_tend) then
                     ustend(i3_f,k,iCell) = FLOAT (INT(ustend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
 
-                 vstend(i3_f,k,iCell) = (-(vws(k-1,iCell) - vws(k,iCell))/dz -  &
-                   vw(i1,k,iCell)*Sz - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 +  &
-                   alpha_tracer2))*ws(i1,k,iCell)*Vz) - vs(i1,k,iCell)*tau_tracer(k,iCell)
+
+!      CALCULATE VT TENDENCY TERMS
+!      The vs tendency is the sum of the following terms (which are NOT saved individually)
+!                   (1) turbulent transport of vs [ -d(vws)/dz ]
+!                   (2) parameterized pressure-strain terms (Rotta, rapid, Stokes)
+!                   (3) gradient production of vs [vw*dS/dz]
+!      The tendency term is truncated if config_adc_truncate_tend flag it switched on
+                 vstend(i3_f,k,iCell) = (-(vws(k-1,iCell) - vws(k,iCell))/dz  & ! Transport
+                   - vs(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
+                   - (1.0_RKIND - 0.5_RKIND*(alpha_tracer1 &
+                   + alpha_tracer2))*ws(i1,k,iCell)*Vz) & ! Rapid
+                   - vw(i1,k,iCell)*Sz ! Gradient production
 
                  if (config_adc_truncate_tend) then
                     vstend(i3_f,k,iCell) = FLOAT (INT(vstend(i3_f,k,iCell) * adcRound &
                       + 0.5_RKIND)) / adcRound
                  endif
+
+
 
                  t2(i2,k,iCell) = tumd(k,iCell)**2.0_RKIND*areaFraction(k,iCell)*&
                    (1.0_RKIND-areaFraction(k,iCell))

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -521,6 +521,8 @@ module ocn_adc_mixing_fused
                  KE = sqrt(0.5_RKIND*(u2(i1,k,iCell) + v2(i1,k,iCell) + areaFraction(k,iCell)* &
                    (1.0_RKIND - areaFraction(k,iCell))*wumd(k,iCell)**2.0_RKIND))
 
+!      Define turbulence timescales/rates for return-to-isotropy tendency terms (Rotta, 1951)
+!      Note that tau_tracer, tauVel and tauvVel are INVERSE timescales (i.e. rates)
                  tau_tracer(k,iCell) = c_slow_tracer*KE / (1.0E-15_RKIND + length(k,iCell))
                  tauVel(k,iCell) = C_slow*KE / (1.0E-15_RKIND + length(k,iCell))
                  tauvVel(k,iCell) = slow_w_factor*C_slow*KE / (1.0E-15_RKIND + length(k,iCell))

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -228,10 +228,29 @@ module ocn_adc_mixing_fused
               enddo
            enddo
 
-!     compute the splat effect, adds w3tend and w2tend
            if(config_adc_use_splat_parameterization) then
-!     do k=1 separately for performance reasons, for k=1 we use one sided derivatives
-!     note that the splat_factor forces the term to be smaller than factor * dt
+
+!   COMPUTE SPLATTING EFFECT ON W2, U2, V2 AND W3
+!   This splatting effect was adopted from the CLUBB code.
+!   It computes the (negative) tendencies of w2 and w3 due to "splatting" of eddies as
+!   their vertical motion is inhibited, e.g., near the surface or mixed layer base.
+!   Near these 'splatting layers', wtend6 removes w2 and redistributes it evenly
+!   between u2 and v2 [via u2tend6 and v2tend6].
+!   The functional forms of splatting terms (w2tend6 and w2tend6) are
+!
+!   w2tend6 \propto - w'2 * (turbulent time scale) * ( d/dz( sqrt(w'2) ) )^2
+!
+!   The functional form of wp3_splat is
+!
+!   wp3_splat \propto - w'3 * (turbulent time scale) * ( d/dz( sqrt(w'2) ) )^2
+!
+!   If the coefficient on wp3_splat is at least 1.5 times greater than the
+!   coefficient on wp2_splat, then skewness will be damped, promoting
+!   more stratiform layers.
+!
+!   The calculation for k=1 is separate for performance reasons (one-sided derivatives)
+!   Note that the splat_factor forces the term to be smaller than factor * dt
+
               k=1
               do iCell=1,nCells
                  d_sqrt_wp2_dz = (sqrt(w2(i1,1,iCell)) - sqrt(0.5_RKIND*(w2(i1,1,iCell)+ &
@@ -989,7 +1008,28 @@ module ocn_adc_mixing_fused
 !     In this step we update second moments except w3 which needs updated w2
            do iCell = 1,nCells
               do k=2,nVertLevels
-!     update second order moment tendency here
+
+!      STEP THE SECOND-MOMENTS FORWARD IN TIME
+!      The tendency terms [w2tend etc.] are used to step the moments forward.
+!      These tendencies are calculated for each moment (arbitrarily XY) using,
+!
+!      XYtend = d(XY)/dt \approx Sources and Sinks of XY
+!
+!      Then, XY_future = XY_past + f(XYtend at different times in past, timestep)
+!
+!      Most of the sources and sinks are included explicitly using the above method.
+!      For the variances (w2, u2, v2) and vertical tracer fluxes (wt, ws), the
+!      'return-to-isotropy' mechanism of pressure terms is included implicitly
+!      instead. This term is parameterized as a sink of XY with
+!               tendency \propto - A* XY/(turbulence timescale)
+!      where A is a constant that can vary between each moment [Rotta, 1951].
+!      The implicit inclusion moves this term from the right- to left-hand side of the
+!      above equation. This results in a modified step-forward,
+!
+!      XY_future = XY_past + f(XYtendencies, timestep)/(1+A*timestep/turbulence_timescale)
+!
+!      Note that the tauvVel, tauVel, tau_tracer terms below are INVERSE timescales.
+
                  w2(i2,k,iCell) = (w2(i1,k,iCell) + dt_small*(Cw3 * w2tend(i3_f,k,iCell)  &
                    + Cw2 * w2tend(i2_f,k,iCell) + Cw1 * w2tend(i1_f,k,iCell))) /           &
                    (1.0_RKIND + dt_small*tauvVel(k,iCell)*2.0_RKIND/3.0_RKIND)


### PR DESCRIPTION
This PR adds commenting to the tendency equations for all the second-moment budgets and for the third-moment budget (`w3`).

Summary of changes in this PR:

1. Commenting is added for the tendency equations, summarizing the physical meaning of each tendency term
2. Tendency terms are re-organized so that they contain specific physical processes (i.e. pressure terms are now grouped together, and separated from buoyancy and shear production terms or from dissipation terms)
3. NetCDF descriptors for these variables have been updated
4. The full Rotta/slow 'return-to-isotropy' term is now included in the pressure tendency term so that it can be compared to LES output and pressure parameterizations. In cases where the Rotta term is imposed implicitly in the timestep, this part of the Rotta contribution is removed at the summation of tendencies stage.
5. Added w2tend6 (splatting) as a saved diagnostic

I have tested this with my current experiment and got bit-for-bit identical second-order moments. My test case is limited to convection, so several of the moments are identically zero. It would be helpful if someone could test that BFB holds in a more complex case (surface salinity flux, non-zero momentum fluxes).
