### PR TITLE
Add Stokes terms to ADC scheme

### DIFF
--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -63,13 +63,33 @@
 	      description="alpha_2 third (vorticity) rapid pressure coefficient"
 	      possible_values="values near 0.6"
 	      />
+  <nml_option name="config_adc_alpha_st_0" type="real" default_value="2.2" units="unitless"
+          description="alpha_st_0 first (TKE) Stokes pressure coefficient for second-moment budgets"
+          possible_values="values near 2.2 (Pearson 2019)"
+          />
+  <nml_option name="config_adc_alpha_st_1" type="real" default_value="1.4" units="unitless"
+          description="alpha_st_1 second (strain) Stokes pressure coefficient"
+          possible_values="values near 1.4 (Pearson 2019)"
+          />
+  <nml_option name="config_adc_alpha_st_2" type="real" default_value="-0.5" units="unitless"
+          description="alpha_st_2 third (vorticity) Stokes pressure coefficient"
+          possible_values="values near -0.5 (Pearson 2019)"
+          />
   <nml_option name="config_adc_alpha_tracer1" type="real" default_value="0.6" units="unitless"
 	      description="alpha_scalar1 first rapid pressure coefficient in tracer flux budgets (Mironov 2001)"
-	      possible_values="suggested values: 0.6 (Canuto 2001) or equal to alpha_scalar2, >0, <1 (Harcourt 2013)"
+	      possible_values="suggested values: 0.6 (Canuto 2001) or 0.7 (Harcourt 2013) or positive and equal to alpha_tracer2 (production cancellation)"
   />
   <nml_option name="config_adc_alpha_tracer2" type="real" default_value="1.0" units="unitless"
 	      description="alpha_scalar2 rapid pressure coefficient in tracer flux budgets (Mironov 2001)"
-	      possible_values="suggested values: 1.0 (Canuto 2001) or equal to alpha_scalar2, >0, <1 (Harcourt 2013)"
+	      possible_values="suggested values: 1.0 (Canuto 2001) or 0.7 (Harcourt 2013) or positive and equal to alpha_tracer1 (production cancellation)"
+  />
+  <nml_option name="config_adc_alpha_st_tracer1" type="real" default_value="0.6" units="unitless"
+          description="alpha_st_scalar1 first Stokes pressure coefficient in tracer flux budgets (analogous to Mironov 2001 shear terms)"
+          possible_values="suggested values: 0.6 (Canuto analogy modified for Stokes production of wscalar) or 0.7 (Harcourt 2013) or POSITIVE and equal to MINUS alpha_tracer2 (production cancellation)"
+  />
+  <nml_option name="config_adc_alpha_st_tracer2" type="real" default_value="-1.0" units="unitless"
+          description="alpha_st_scalar2 second Stokes pressure coefficient in tracer flux budgets (analogous to Mironov 2001 shear terms)"
+          possible_values="suggested values: -1.0 (Canuto analogy modified for Stokes production of wscalar) or 0.7 (Harcourt 2013) or NEGATIVE and equal to MINUS alpha_tracer1 (production cancellation)"
   />
   <nml_option name="config_adc_c11" type="real" default_value="0.1" units="unitless"
 	      description="c_11 is the buoyancy contribution in the pressure correlation in w3 eqn"
@@ -292,23 +312,29 @@
   <var name="w2tend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="conversion of w2 to u2/v2 due to splat effects"
        />
-  <var name="w3tend1" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+  <var name="w2tend7" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="Stokes production of w2 [-2*[uw*d(ustokes)/dz + vw*d(vstokes)/dz]"
+       />
+  <var name="w3tend1" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^4"
        description="entrainment/detrainment term -- similar to dissipation"
        />
-  <var name="w3tend2" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+  <var name="w3tend2" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^4"
        description="turbulent transport of w3 [ -d(w^4)/dz ]"
        />
-  <var name="w3tend3" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+  <var name="w3tend3" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^4"
        description="gradient production of w3 [ (3/2)*d( [w2]^2 )/dz ]"
        />
-  <var name="w3tend4" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+  <var name="w3tend4" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^4"
        description="parameterized pressure terms (Rotta, buoyancy)"
        />
-  <var name="w3tend5" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+  <var name="w3tend5" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^4"
        description="buoyancy production and sub-plume scale effects"
        />
-  <var name="w3tend6" type="real" dimensions="nVertLevels nCells Time" units="m^2/s^3"
+  <var name="w3tend6" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^4"
        description="destruction due to splat effects"
+       />
+  <var name="w3tend7" type="real" dimensions="nVertLevels nCells Time" units="m^3/s^4"
+       description="Stokes production of w3 -3*[uw2*d(ustokes)/dz + vw2*d(ustokes)/dz]"
        />
   <var name="wttend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
        description="entrainment/detrainment term -- similar to dissipation"
@@ -328,6 +354,9 @@
   <var name="wttend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
        description="subplume scale production term"
        />
+  <var name="wttend7" type="real" dimensions="nVertLevelsP1 nCells Time" units="m C/s^2"
+       description="Stokes production of wt -[ut*d(ustokes)/dz + vt*d(vstokes)/dz]"
+       />
   <var name="wstend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
        description="entrainment/detrainment term -- similar to dissipation"
        />
@@ -346,6 +375,9 @@
   <var name="wstend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
        description="subplume scale production term"
        />
+  <var name="wstend7" type="real" dimensions="nVertLevelsP1 nCells Time" units="m PSU/s^2"
+       description="Stokes production of ws -[us*d(ustokes)/dz + vs*d(vstokes)/dz]"
+       />
   <var name="uwtend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="turbulent transport of uw [ -d(uww)/dz ]"
        />
@@ -361,6 +393,9 @@
   <var name="uwtend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="dissipation of uw [-kappa_FL*[d(uw)/dz]^2] "
        />
+  <var name="uwtend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="Stokes production of uw -[u2*d(ustokes)/dz + uv*d(vstokes)/dz]"
+       />
   <var name="vwtend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="turbulent transport of vw [ -d(vww)/dz ]"
        />
@@ -375,6 +410,9 @@
        />
   <var name="vwtend5" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="dissipation of uw [-kappa_FL*[d(uw)/dz]^2]"
+       />
+  <var name="vwtend6" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
+       description="Stokes production of vw -[uv*d(ustokes)/dz + v2*d(vstokes)/dz]"
        />
   <var name="u2tend1" type="real" dimensions="nVertLevelsP1 nCells Time" units="m^2/s^3"
        description="turbulent transport of u2 [ -d(uuw)/dz ]"
@@ -586,6 +624,7 @@
     <var name="w2tend4"/>
     <var name="w2tend5"/>
     <var name="w2tend6"/>
+    <var name="w2tend7"/>
     <var name="u2tend1"/>
     <var name="u2tend2"/>
     <var name="u2tend3"/>
@@ -601,26 +640,31 @@
     <var name="uwtend3"/>
     <var name="uwtend4"/>
     <var name="uwtend5"/>
+    <var name="uwtend6"/>
     <var name="vwtend1"/>
     <var name="vwtend2"/>
     <var name="vwtend3"/>
     <var name="vwtend4"/>
     <var name="vwtend5"/>
+    <var name="vwtend6"/>
     <var name="w3tend1"/>
     <var name="w3tend2"/>
     <var name="w3tend3"/>
     <var name="w3tend4"/>
     <var name="w3tend5"/>
+    <var name="w3tend6"/>
     <var name="wttend1"/>
     <var name="wttend2"/>
     <var name="wttend3"/>
     <var name="wttend4"/>
     <var name="wttend5"/>
+    <var name="wttend6"/>
     <var name="wstend1"/>
     <var name="wstend2"/>
     <var name="wstend3"/>
     <var name="wstend4"/>
     <var name="wstend5"/>
+    <var name="wstend6"/>
     <var name="u2"/>
     <var name="v2"/>
     <var name="w2"/>

--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -32,7 +32,7 @@
           possible_values="positive real numbers"
           />
   <nml_option name="config_adc_stokes_angle" type="real" default_value="0.0" units="radians"
-          description="Angle between wind and waves (surface stress and surface Stokes drift vector respectively). Positive values denote waves to the left of the wind. NOTE: units are RADIANS."
+          description="Angle between wind and waves (surface stress and surface Stokes drift vector respectively). Positive values denote waves to the left of the wind."
           possible_values="positive or negative real numbers"
           />
   <nml_option name="config_adc_tau_o" type="real" default_value="1800" units="s^{-1}"

--- a/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
+++ b/src/core_ocean/adc_mixing/Registry_adc_mixing_fields_opts.xml
@@ -19,6 +19,22 @@
 	      description="number of decimal places to keep, inverse is position of decimal rounding"
 	      possible_values="large positive reals"
 	      />
+  <nml_option name="config_adc_langmuir" type="logical" default_value=".false." units="unitless"
+          description="Switch to turn on wave effects (Langmuir turbulence) in ADC scheme. If false the Stokes drift of waves is set to zero. "
+          possible_values=".true. or .false."
+          />
+  <nml_option name="config_adc_La_t" type="real" default_value="0.3" units="unitless"
+          description="Turbulent Langmuir number La_t = SQRT(friction velocity / surface Stokes drift magnitude). Default value is that of an 'equilibrium wind-sea'."
+          possible_values="positive real numbers, increasing values indicate weaker waves"
+          />
+  <nml_option name="config_adc_stokes_depth" type="real" default_value="4.8" units="m"
+          description="Exponential decay depth of Stokes drift profile. Default value is common in LES studies."
+          possible_values="positive real numbers"
+          />
+  <nml_option name="config_adc_stokes_angle" type="real" default_value="0.0" units="radians"
+          description="Angle between wind and waves (surface stress and surface Stokes drift vector respectively). Positive values denote waves to the left of the wind. NOTE: units are RADIANS."
+          possible_values="positive or negative real numbers"
+          />
   <nml_option name="config_adc_tau_o" type="real" default_value="1800" units="s^{-1}"
 	      description="characterstic eddy turnover timescale"
 	      possible_values="positive real numbers"

--- a/src/core_ocean/adc_mixing/mpas_ocn_turbulence.F
+++ b/src/core_ocean/adc_mixing/mpas_ocn_turbulence.F
@@ -53,16 +53,16 @@ module ocn_turbulence
                        uws, vws, ws2, wt2, sigma, Entrainment,        &
                        Detrainment, tumd, sumd, wumd, Mc
 
-   real(kind=RKIND), dimension(:,:), pointer :: w2tend1, w2tend2, w2tend3,     &
-                       w2tend4, w2tend5, w2tend6, w2tend7, wttend1, wttend2,   &
-                       wttend3, wttend4, wttend5, wttend6, wttend7, w3tend1,   &
-                       w3tend2, w3tend3, w3tend4, w3tend5, w3tend6, w3tend7,   &
-                       wstend1, wstend2, wstend3, wstend4, wstend5, wstend6,   &
-                       wstend7, uwtend1, uwtend2, uwtend3, uwtend4, uwtend5,   &
-                       uwtend6, vwtend1, vwtend2, vwtend3, vwtend4, vwtend5,   &
-                       vwtend6, u2tend1, u2tend2, u2tend3, u2tend4, u2tend5,   &
-                       u2tend6, v2tend1, v2tend2, v2tend3, v2tend4, v2tend5,   &
-                       v2tend6, u2cliptend, v2cliptend, w2cliptend
+   real(kind=RKIND), dimension(:,:), pointer :: w2tend1, w2tend2,     &
+                       w2tend3, w2tend4, w2tend5, w2tend6, wttend1, wttend2,   &
+                       wttend3, wttend4, wttend5, w3tend1, w3tend2,   &
+                       w3tend3, w3tend5, w3tend4, wstend1, wstend2,   &
+                       wstend3, wstend4, wstend5, uwtend1, uwtend2,   &
+                       uwtend3, uwtend4, uwtend5, vwtend1, vwtend2,   &
+                       vwtend3, vwtend4, vwtend5, u2tend1, u2tend2,   &
+                       u2tend3, u2tend4, u2tend5, v2tend1, v2tend2,   &
+                       v2tend3, v2tend4, v2tend5, u2cliptend,         &
+                       v2cliptend, w2cliptend
 
    real(kind=RKIND), dimension(:,:,:), pointer :: u2, v2, w2, t2, s2, &
                        uw, vw, wt, ws, w3, uv, ut, vt, us, vs, ts
@@ -103,18 +103,17 @@ module ocn_turbulence
                        uwsTmp, vwsTmp, ws2Tmp, wt2Tmp, sigmaTmp, EntrainmentTmp,        &
                        DetrainmentTmp, tumdTmp, sumdTmp, wumdTmp, McTmp
 
-   real(kind=RKIND), dimension(:,:), pointer :: w2tend1Tmp, w2tend2Tmp, w2tend3Tmp,  &
-                       w2tend4Tmp, w2tend5Tmp, w2tend6Tmp, w2tend7Tmp, wttend1Tmp,   &
-                       wttend2Tmp, wttend3Tmp, wttend4Tmp, wttend5Tmp, wttend6Tmp,   &
-                       wttend7Tmp, w3tend1Tmp, w3tend2Tmp, w3tend3Tmp, w3tend5Tmp,   &
-                       w3tend4Tmp, w3tend5Tmp, w3tend6Tmp, w3tend7Tmp, wstend1Tmp,   &
-                       wstend2Tmp, wstend3Tmp, wstend4Tmp, wstend5Tmp, wstend6Tmp,   &
-                       wstend7Tmp, uwtend1Tmp, uwtend2Tmp, uwtend3Tmp, uwtend4Tmp,   &
-                       uwtend5Tmp, uwtend6Tmp, vwtend1Tmp, vwtend2Tmp, vwtend3Tmp,   &
-                       vwtend4Tmp, vwtend5Tmp, vwtend6Tmp, u2tend1Tmp, u2tend2Tmp,   &
-                       u2tend3Tmp, u2tend4Tmp, u2tend5Tmp, u2tend6Tmp, v2tend1Tmp,   &
-                       v2tend2Tmp, v2tend3Tmp, v2tend4Tmp, v2tend5Tmp, v2tend6Tmp,   &
-                       u2cliptendTmp, v2cliptendTmp, w2cliptendTmp
+   real(kind=RKIND), dimension(:,:), pointer :: w2tend1Tmp, w2tend2Tmp,     &
+                       w2tend3Tmp, w2tend4Tmp, w2tend5Tmp, w2tend6Tmp, &
+                       wttend1Tmp, wttend2Tmp,   &
+                       wttend3Tmp, wttend4Tmp, wttend5Tmp, w3tend1Tmp, w3tend2Tmp,   &
+                       w3tend3Tmp, w3tend5Tmp, w3tend4Tmp, wstend1Tmp, wstend2Tmp,   &
+                       wstend3Tmp, wstend4Tmp, wstend5Tmp, uwtend1Tmp, uwtend2Tmp,   &
+                       uwtend3Tmp, uwtend4Tmp, uwtend5Tmp, vwtend1Tmp, vwtend2Tmp,   &
+                       vwtend3Tmp, vwtend4Tmp, vwtend5Tmp, u2tend1Tmp, u2tend2Tmp,   &
+                       u2tend3Tmp, u2tend4Tmp, u2tend5Tmp, v2tend1Tmp, v2tend2Tmp,   &
+                       v2tend3Tmp, v2tend4Tmp, v2tend5Tmp, u2cliptendTmp,         &
+                       v2cliptendTmp, w2cliptendTmp
 
    real(kind=RKIND), dimension(:,:,:), pointer :: u2Tmp, v2Tmp, w2Tmp, t2Tmp, s2Tmp, &
                        uwTmp, vwTmp, wtTmp, wsTmp, w3Tmp, uvTmp, utTmp, vtTmp, usTmp,&
@@ -234,52 +233,41 @@ module ocn_turbulence
       call mpas_pool_get_array(adcTendPool, 'w2tend4', w2tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend5', w2tend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend6', w2tend6Tmp)
-      call mpas_pool_get_array(adcTendPool, 'w2tend7', w2tend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend1', w3tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend2', w3tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend3', w3tend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend4', w3tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend5', w3tend5Tmp)
-      call mpas_pool_get_array(adcTendPool, 'w3tend6', w3tend6Tmp)
-      call mpas_pool_get_array(adcTendPool, 'w3tend7', w3tend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend1', wttend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend2', wttend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend3', wttend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend4', wttend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend5', wttend5Tmp)
-      call mpas_pool_get_array(adcTendPool, 'wttend6', wttend6Tmp)
-      call mpas_pool_get_array(adcTendPool, 'wttend7', wttend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend1', wstend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend2', wstend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend3', wstend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend4', wstend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend5', wstend5Tmp)
-      call mpas_pool_get_array(adcTendPool, 'wstend6', wstend6Tmp)
-      call mpas_pool_get_array(adcTendPool, 'wstend7', wstend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend1', uwtend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend2', uwtend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend3', uwtend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend4', uwtend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend5', uwtend5Tmp)
-      call mpas_pool_get_array(adcTendPool, 'uwtend6', uwtend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend1', vwtend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend2', vwtend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend3', vwtend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend4', vwtend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend5', vwtend5Tmp)
-      call mpas_pool_get_array(adcTendPool, 'vwtend6', vwtend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend1', u2tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend2', u2tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend3', u2tend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend4', u2tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend5', u2tend5Tmp)
-      call mpas_pool_get_array(adcTendPool, 'u2tend6', u2tend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend1', v2tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend2', v2tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend3', v2tend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend4', v2tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend5', v2tend5Tmp)
-      call mpas_pool_get_array(adcTendPool, 'v2tend6', v2tend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2cliptend', u2cliptendTmp)
       call mpas_pool_get_array(adcTendPool, 'v2cliptend', v2cliptendTmp)
       call mpas_pool_get_array(adcTendPool, 'w2cliptend', w2cliptendTmp)
@@ -290,52 +278,41 @@ module ocn_turbulence
       adcMixing%w2tend4 = w2tend4Tmp
       adcMixing%w2tend5 = w2tend5Tmp
       adcMixing%w2tend6 = w2tend6Tmp
-      adcMixing%w2tend7 = w2tend7Tmp
       adcMixing%w3tend1 = w3tend1Tmp
       adcMixing%w3tend2 = w3tend2Tmp
       adcMixing%w3tend3 = w3tend3Tmp
       adcMixing%w3tend4 = w3tend4Tmp
       adcMixing%w3tend5 = w3tend5Tmp
-      adcMixing%w3tend6 = w3tend6Tmp
-      adcMixing%w3tend7 = w3tend7Tmp
       adcMixing%wttend1 = wttend1Tmp
       adcMixing%wttend2 = wttend2Tmp
       adcMixing%wttend3 = wttend3Tmp
       adcMixing%wttend4 = wttend4Tmp
       adcMixing%wttend5 = wttend5Tmp
-      adcMixing%wttend6 = wttend6Tmp
-      adcMixing%wttend7 = wttend7Tmp
       adcMixing%wstend1 = wstend1Tmp
       adcMixing%wstend2 = wstend2Tmp
       adcMixing%wstend3 = wstend3Tmp
       adcMixing%wstend4 = wstend4Tmp
       adcMixing%wstend5 = wstend5Tmp
-      adcMixing%wstend6 = wstend6Tmp
-      adcMixing%wstend7 = wstend7Tmp
       adcMixing%uwtend1 = uwtend1Tmp
       adcMixing%uwtend2 = uwtend2Tmp
       adcMixing%uwtend3 = uwtend3Tmp
       adcMixing%uwtend4 = uwtend4Tmp
       adcMixing%uwtend5 = uwtend5Tmp
-      adcMixing%uwtend6 = uwtend6Tmp
       adcMixing%vwtend1 = vwtend1Tmp
       adcMixing%vwtend2 = vwtend2Tmp
       adcMixing%vwtend3 = vwtend3Tmp
       adcMixing%vwtend4 = vwtend4Tmp
       adcMixing%vwtend5 = vwtend5Tmp
-      adcMixing%vwtend6 = vwtend6Tmp
       adcMixing%u2tend1 = u2tend1Tmp
       adcMixing%u2tend2 = u2tend2Tmp
       adcMixing%u2tend3 = u2tend3Tmp
       adcMixing%u2tend4 = u2tend4Tmp
       adcMixing%u2tend5 = u2tend5Tmp
-      adcMixing%u2tend6 = u2tend6Tmp
       adcMixing%v2tend1 = v2tend1Tmp
       adcMixing%v2tend2 = v2tend2Tmp
       adcMixing%v2tend3 = v2tend3Tmp
       adcMixing%v2tend4 = v2tend4Tmp
       adcMixing%v2tend5 = v2tend5Tmp
-      adcMixing%v2tend6 = v2tend6Tmp
       adcMixing%u2cliptend = u2cliptendTmp
       adcMixing%v2cliptend = v2cliptendTmp
       adcMixing%w2cliptend = w2cliptendTmp

--- a/src/core_ocean/adc_mixing/mpas_ocn_turbulence.F
+++ b/src/core_ocean/adc_mixing/mpas_ocn_turbulence.F
@@ -53,16 +53,16 @@ module ocn_turbulence
                        uws, vws, ws2, wt2, sigma, Entrainment,        &
                        Detrainment, tumd, sumd, wumd, Mc
 
-   real(kind=RKIND), dimension(:,:), pointer :: w2tend1, w2tend2,     &
-                       w2tend3, w2tend4, w2tend5, w2tend6, wttend1, wttend2,   &
-                       wttend3, wttend4, wttend5, w3tend1, w3tend2,   &
-                       w3tend3, w3tend5, w3tend4, wstend1, wstend2,   &
-                       wstend3, wstend4, wstend5, uwtend1, uwtend2,   &
-                       uwtend3, uwtend4, uwtend5, vwtend1, vwtend2,   &
-                       vwtend3, vwtend4, vwtend5, u2tend1, u2tend2,   &
-                       u2tend3, u2tend4, u2tend5, v2tend1, v2tend2,   &
-                       v2tend3, v2tend4, v2tend5, u2cliptend,         &
-                       v2cliptend, w2cliptend
+   real(kind=RKIND), dimension(:,:), pointer :: w2tend1, w2tend2, w2tend3,     &
+                       w2tend4, w2tend5, w2tend6, w2tend7, wttend1, wttend2,   &
+                       wttend3, wttend4, wttend5, wttend6, wttend7, w3tend1,   &
+                       w3tend2, w3tend3, w3tend4, w3tend5, w3tend6, w3tend7,   &
+                       wstend1, wstend2, wstend3, wstend4, wstend5, wstend6,   &
+                       wstend7, uwtend1, uwtend2, uwtend3, uwtend4, uwtend5,   &
+                       uwtend6, vwtend1, vwtend2, vwtend3, vwtend4, vwtend5,   &
+                       vwtend6, u2tend1, u2tend2, u2tend3, u2tend4, u2tend5,   &
+                       u2tend6, v2tend1, v2tend2, v2tend3, v2tend4, v2tend5,   &
+                       v2tend6, u2cliptend, v2cliptend, w2cliptend
 
    real(kind=RKIND), dimension(:,:,:), pointer :: u2, v2, w2, t2, s2, &
                        uw, vw, wt, ws, w3, uv, ut, vt, us, vs, ts
@@ -103,17 +103,18 @@ module ocn_turbulence
                        uwsTmp, vwsTmp, ws2Tmp, wt2Tmp, sigmaTmp, EntrainmentTmp,        &
                        DetrainmentTmp, tumdTmp, sumdTmp, wumdTmp, McTmp
 
-   real(kind=RKIND), dimension(:,:), pointer :: w2tend1Tmp, w2tend2Tmp,     &
-                       w2tend3Tmp, w2tend4Tmp, w2tend5Tmp, w2tend6Tmp, &
-                       wttend1Tmp, wttend2Tmp,   &
-                       wttend3Tmp, wttend4Tmp, wttend5Tmp, w3tend1Tmp, w3tend2Tmp,   &
-                       w3tend3Tmp, w3tend5Tmp, w3tend4Tmp, wstend1Tmp, wstend2Tmp,   &
-                       wstend3Tmp, wstend4Tmp, wstend5Tmp, uwtend1Tmp, uwtend2Tmp,   &
-                       uwtend3Tmp, uwtend4Tmp, uwtend5Tmp, vwtend1Tmp, vwtend2Tmp,   &
-                       vwtend3Tmp, vwtend4Tmp, vwtend5Tmp, u2tend1Tmp, u2tend2Tmp,   &
-                       u2tend3Tmp, u2tend4Tmp, u2tend5Tmp, v2tend1Tmp, v2tend2Tmp,   &
-                       v2tend3Tmp, v2tend4Tmp, v2tend5Tmp, u2cliptendTmp,         &
-                       v2cliptendTmp, w2cliptendTmp
+   real(kind=RKIND), dimension(:,:), pointer :: w2tend1Tmp, w2tend2Tmp, w2tend3Tmp,  &
+                       w2tend4Tmp, w2tend5Tmp, w2tend6Tmp, w2tend7Tmp, wttend1Tmp,   &
+                       wttend2Tmp, wttend3Tmp, wttend4Tmp, wttend5Tmp, wttend6Tmp,   &
+                       wttend7Tmp, w3tend1Tmp, w3tend2Tmp, w3tend3Tmp, w3tend5Tmp,   &
+                       w3tend4Tmp, w3tend5Tmp, w3tend6Tmp, w3tend7Tmp, wstend1Tmp,   &
+                       wstend2Tmp, wstend3Tmp, wstend4Tmp, wstend5Tmp, wstend6Tmp,   &
+                       wstend7Tmp, uwtend1Tmp, uwtend2Tmp, uwtend3Tmp, uwtend4Tmp,   &
+                       uwtend5Tmp, uwtend6Tmp, vwtend1Tmp, vwtend2Tmp, vwtend3Tmp,   &
+                       vwtend4Tmp, vwtend5Tmp, vwtend6Tmp, u2tend1Tmp, u2tend2Tmp,   &
+                       u2tend3Tmp, u2tend4Tmp, u2tend5Tmp, u2tend6Tmp, v2tend1Tmp,   &
+                       v2tend2Tmp, v2tend3Tmp, v2tend4Tmp, v2tend5Tmp, v2tend6Tmp,   &
+                       u2cliptendTmp, v2cliptendTmp, w2cliptendTmp
 
    real(kind=RKIND), dimension(:,:,:), pointer :: u2Tmp, v2Tmp, w2Tmp, t2Tmp, s2Tmp, &
                        uwTmp, vwTmp, wtTmp, wsTmp, w3Tmp, uvTmp, utTmp, vtTmp, usTmp,&
@@ -233,41 +234,52 @@ module ocn_turbulence
       call mpas_pool_get_array(adcTendPool, 'w2tend4', w2tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend5', w2tend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend6', w2tend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'w2tend7', w2tend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend1', w3tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend2', w3tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend3', w3tend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend4', w3tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend5', w3tend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'w3tend6', w3tend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'w3tend7', w3tend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend1', wttend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend2', wttend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend3', wttend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend4', wttend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend5', wttend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'wttend6', wttend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'wttend7', wttend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend1', wstend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend2', wstend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend3', wstend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend4', wstend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend5', wstend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'wstend6', wstend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'wstend7', wstend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend1', uwtend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend2', uwtend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend3', uwtend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend4', uwtend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend5', uwtend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'uwtend6', uwtend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend1', vwtend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend2', vwtend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend3', vwtend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend4', vwtend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend5', vwtend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'vwtend6', vwtend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend1', u2tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend2', u2tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend3', u2tend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend4', u2tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend5', u2tend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'u2tend6', u2tend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend1', v2tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend2', v2tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend3', v2tend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend4', v2tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'v2tend5', v2tend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'v2tend6', v2tend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2cliptend', u2cliptendTmp)
       call mpas_pool_get_array(adcTendPool, 'v2cliptend', v2cliptendTmp)
       call mpas_pool_get_array(adcTendPool, 'w2cliptend', w2cliptendTmp)
@@ -278,41 +290,52 @@ module ocn_turbulence
       adcMixing%w2tend4 = w2tend4Tmp
       adcMixing%w2tend5 = w2tend5Tmp
       adcMixing%w2tend6 = w2tend6Tmp
+      adcMixing%w2tend7 = w2tend7Tmp
       adcMixing%w3tend1 = w3tend1Tmp
       adcMixing%w3tend2 = w3tend2Tmp
       adcMixing%w3tend3 = w3tend3Tmp
       adcMixing%w3tend4 = w3tend4Tmp
       adcMixing%w3tend5 = w3tend5Tmp
+      adcMixing%w3tend6 = w3tend6Tmp
+      adcMixing%w3tend7 = w3tend7Tmp
       adcMixing%wttend1 = wttend1Tmp
       adcMixing%wttend2 = wttend2Tmp
       adcMixing%wttend3 = wttend3Tmp
       adcMixing%wttend4 = wttend4Tmp
       adcMixing%wttend5 = wttend5Tmp
+      adcMixing%wttend6 = wttend6Tmp
+      adcMixing%wttend7 = wttend7Tmp
       adcMixing%wstend1 = wstend1Tmp
       adcMixing%wstend2 = wstend2Tmp
       adcMixing%wstend3 = wstend3Tmp
       adcMixing%wstend4 = wstend4Tmp
       adcMixing%wstend5 = wstend5Tmp
+      adcMixing%wstend6 = wstend6Tmp
+      adcMixing%wstend7 = wstend7Tmp
       adcMixing%uwtend1 = uwtend1Tmp
       adcMixing%uwtend2 = uwtend2Tmp
       adcMixing%uwtend3 = uwtend3Tmp
       adcMixing%uwtend4 = uwtend4Tmp
       adcMixing%uwtend5 = uwtend5Tmp
+      adcMixing%uwtend6 = uwtend6Tmp
       adcMixing%vwtend1 = vwtend1Tmp
       adcMixing%vwtend2 = vwtend2Tmp
       adcMixing%vwtend3 = vwtend3Tmp
       adcMixing%vwtend4 = vwtend4Tmp
       adcMixing%vwtend5 = vwtend5Tmp
+      adcMixing%vwtend6 = vwtend6Tmp
       adcMixing%u2tend1 = u2tend1Tmp
       adcMixing%u2tend2 = u2tend2Tmp
       adcMixing%u2tend3 = u2tend3Tmp
       adcMixing%u2tend4 = u2tend4Tmp
       adcMixing%u2tend5 = u2tend5Tmp
+      adcMixing%u2tend6 = u2tend6Tmp
       adcMixing%v2tend1 = v2tend1Tmp
       adcMixing%v2tend2 = v2tend2Tmp
       adcMixing%v2tend3 = v2tend3Tmp
       adcMixing%v2tend4 = v2tend4Tmp
       adcMixing%v2tend5 = v2tend5Tmp
+      adcMixing%v2tend6 = v2tend6Tmp
       adcMixing%u2cliptend = u2cliptendTmp
       adcMixing%v2cliptend = v2cliptendTmp
       adcMixing%w2cliptend = w2cliptendTmp

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -233,8 +233,6 @@ module ocn_adc_mixing_fused
 !             La_t = (friction velocity / surface stokes drift magnitude)^(0.5) and the
 !             stokes_angle (angle between surface stress and Stokes drift vectors)
 
-!              uStokes(1,iCell) = uStokes_surf
-!              vStokes(1,iCell) = vStokes_surf
               do k=1,nVertLevels
 !                Calculate Stokes drift at vertical edge of cells
                  uStokes(k,iCell) = uStokes_surf*EXP(ze(k,iCell)/stokes_depth)

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -182,7 +182,7 @@ module ocn_adc_mixing_fused
 
       real(kind=RKIND),dimension(nVertLevels,nCells) :: Swumd
       real(kind=RKIND),dimension(nVertLevels,nCells) :: tauw3, tau_tracer, tauVel, tauvVel
-      real(kind=RKIND),dimension(nVertLevels,nCells) :: uStokes, vStokes
+      real(kind=RKIND),dimension(nVertLevels,nCells) :: uStokes, vStokes, uStokesm, vStokesm
       real(kind=RKIND),dimension(nVertLevels,nCells) :: areaFractionMid, tumdMid, McMid, wumdMid, sumdMid
 
       real(kind=RKIND) :: SwU, SwD, tau_sfc, d_sqrt_wp2_dz, tp2, sp2, min_wp2_sfc_val, wp2_splat_sfc_correction
@@ -233,11 +233,15 @@ module ocn_adc_mixing_fused
 !             La_t = (friction velocity / surface stokes drift magnitude)^(0.5) and the
 !             stokes_angle (angle between surface stress and Stokes drift vectors)
 
-              uStokes(1,iCell) = uStokes_surf
-              vStokes(1,iCell) = vStokes_surf
+!              uStokes(1,iCell) = uStokes_surf
+!              vStokes(1,iCell) = vStokes_surf
               do k=1,nVertLevels
+!                Calculate Stokes drift at vertical edge of cells
                  uStokes(k,iCell) = uStokes_surf*EXP(ze(k,iCell)/stokes_depth)
                  vStokes(k,iCell) = vStokes_surf*EXP(ze(k,iCell)/stokes_depth)
+!                Calculate Stokes drift at vertical midpoint of cells
+                 uStokesm(k,iCell) = uStokes_surf*EXP(zm(k,iCell)/stokes_depth)
+                 vStokesm(k,iCell) = vStokes_surf*EXP(zm(k,iCell)/stokes_depth)
               enddo
 
               do k=1,3
@@ -470,6 +474,7 @@ module ocn_adc_mixing_fused
                 SwD = -(1.0_RKIND-2.0_RKIND*areaFraction(k+1,iCell)) &
                    /(areaFraction(k+1,iCell)*(1.0_RKIND-areaFraction(k+1,iCell)))**0.5_RKIND
 
+!    Calculate Stokes drift derivatives at vertical cell centers (where w3 is located)
                 Ustz = (uStokes(k,iCell) - uStokes(k+1,iCell)) / dz
                 Vstz = (vStokes(k,iCell) - vStokes(k+1,iCell)) / dz
 
@@ -546,8 +551,9 @@ module ocn_adc_mixing_fused
 
                  Uz = (uvel(k-1,iCell) - uvel(k,iCell)) / dzmid
                  Vz = (vvel(k-1,iCell) - vvel(k,iCell)) / dzmid
-                 Ustz = (uStokes(k-1,iCell) - uStokes(k,iCell)) / dzmid
-                 Vstz = (vStokes(k-1,iCell) - vStokes(k,iCell)) / dzmid
+!    Calculate Stokes drift derivatives at vertical cell edges (where w2 etc. are located)
+                 Ustz = (uStokesm(k-1,iCell) - uStokesm(k,iCell)) / dzmid
+                 Vstz = (vStokesm(k-1,iCell) - vStokesm(k,iCell)) / dzmid
                  Tz = (activeTracers(1,k-1,iCell) - activeTracers(1,k,iCell)) / dzmid
                  Sz = (activeTracers(2,k-1,iCell) - activeTracers(2,k,iCell)) / dzmid
                  

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -1014,10 +1014,8 @@ module ocn_adc_mixing_fused
                       eps(i1,k+1,iCell)) / (ze(k,iCell) - ze(k+1,iCell) + 1.0E-10_RKIND)
                     
                     epstend(i3_f,k,iCell) = (tomUP - tomDN) / (zm(k-1,iCell) - zm(k,iCell) + 1.0E-10_RKIND) &
-                      - 2.88_RKIND/(tau + 1.0E-10_RKIND)*uw(i1,k,iCell)*(uvel(k-1,iCell) - uvel(k,iCell)) / &
-                      (zm(k-1,iCell) - zm(k,iCell)) &
-                      - 2.88_RKIND/(tau + 1.0E-10_RKIND)*vw(i1,k,iCell)*(vvel(k-1,iCell) - vvel(k,iCell)) / &
-                      (zm(k-1,iCell) - zm(k,iCell)) &
+                      - 2.88_RKIND/(tau + 1.0E-10_RKIND)*(uw(i1,k,iCell)*Uz + vw(i1,k,iCell)*Vz) &
+                      - 2.88_RKIND/(tau + 1.0E-10_RKIND)*(uw(i1,k,iCell)*Ustz + vw(i1,k,iCell)*Vstz) &
                       + 2.88_RKIND/(tau + 1.0E-10_RKIND)*grav*(alphaT(k,iCell)*wt(i1,k,iCell) - betaS(k,iCell)* &
                       ws(i1,k,iCell)) - 3.84_RKIND*eps(i1,k,iCell)/(tau + 1.0E-10_RKIND)
                  endif
@@ -1055,7 +1053,7 @@ module ocn_adc_mixing_fused
                    (ze(k,iCell) - ze(k+1,iCell))) / dzmid -                                 &
                    Cval*KspsU(i1,k,iCell)**1.5_RKIND/(1.0E-15_RKIND + lenspsU(k,iCell)) +                     &
                    eps(i1,k,iCell) / (2.0_RKIND*(1.0_RKIND - areaFraction(k,iCell))) + KmU(k,iCell)* &
-                   (Uz**2.0_RKIND + Vz**2.0_RKIND)
+                   (Uz**2.0_RKIND + Vz**2.0_RKIND + Uz*Ustz + Vz*Vstz)
 
                  if (config_adc_truncate_tend) then
                     KspsUtend(i3_f,k,iCell) = FLOAT (INT(KspsUtend(i3_f,k,iCell) * adcRound &
@@ -1076,7 +1074,7 @@ module ocn_adc_mixing_fused
                    (ze(k,iCell) - ze(k+1,iCell))) / dz -                                 &
                    Cval*KspsD(i1,k,iCell)**1.5_RKIND /(1.0E-15_RKIND + lenspsD(k,iCell)) +                   &
                    eps(i1,k,iCell) / (2.0_RKIND*(areaFraction(k,iCell))) + &
-                   KmD(k,iCell)*(Uz**2.0_RKIND + Vz**2.0_RKIND)
+                   KmD(k,iCell)*(Uz**2.0_RKIND + Vz**2.0_RKIND + Uz*Ustz + Vz*Vstz)
 
                  if (config_adc_truncate_tend) then
                     KspsDtend(i3_f,k,iCell) = FLOAT (INT(KspsDtend(i3_f,k,iCell) * adcRound &

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -178,7 +178,7 @@ module ocn_adc_mixing_fused
       real(kind=RKIND) :: B, Cval, diff, wtav, dzmid, Ksps, Sz, Tz, w4k, w4kp1, w2k, w2kp1
       real(kind=RKIND) :: lareaFraction, wstar, Q, w3av, tempMoment, frictionVelocity
       real(kind=RKIND) :: sfcFrictionVelocitySquared, wtSumUp, wtSumDn, wsSumUp, wsSumDn
-      real(kind=RKIND) :: uStokes_surf, vStokes_surf, stokes_decay_depth, La_t
+      real(kind=RKIND) :: uStokes_surf, vStokes_surf
 
       real(kind=RKIND),dimension(nVertLevels,nCells) :: Swumd
       real(kind=RKIND),dimension(nVertLevels,nCells) :: tauw3, tau_tracer, tauVel, tauvVel
@@ -219,20 +219,25 @@ module ocn_adc_mixing_fused
               frictionVelocity = sqrt(sfcFrictionVelocitySquared + config_adc_bc_wstar * wstar * wstar)
               frictionVelocity = max( config_adc_frictionVelocityMin, frictionVelocity )
 
+              ! Initialize Stokes drift surface values as zero, overwrite these if config_adc_langmuir = .True.
+              uStokes_surf = 0.0_RKIND
+              vStokes_surf = 0.0_RKIND
+              if (config_adc_langmuir) then
+                  uStokes_surf = COS(stokes_angle)*frictionVelocity / (La_t**2.0_RKIND)
+                  vStokes_surf = SIN(stokes_angle)*frictionVelocity / (La_t**2.0_RKIND)
+              endif
+
 !             Calculate exponential Stokes drift profiles from surface values & decay depth
 !             [stokes_decay_depth]. This is temporary; eventually MPAS will pass profiles
-!             For now this is calculated using an assumed Langmuir number of La_t and waves in
-!             x/u-direction only
-!             La_t = (friction velocity / surface stokes drift)^(0.5)
-              La_t = 0.3_RKIND
-              stokes_decay_depth = 4.8_RKIND
-              uStokes_surf = 0.0_RKIND !frictionVelocity / (La_t**2.0_RKIND)
-              vStokes_surf = 0.0_RKIND
+!             For now this is calculated using the turbulent Langmuir number La_t
+!             La_t = (friction velocity / surface stokes drift magnitude)^(0.5) and the
+!             stokes_angle (angle between surface stress and Stokes drift vectors)
+
               uStokes(1,iCell) = uStokes_surf
               vStokes(1,iCell) = vStokes_surf
               do k=1,nVertLevels
-                 uStokes(k,iCell) = uStokes_surf*EXP(ze(k,iCell)/stokes_decay_depth)
-                 vStokes(k,iCell) = vStokes_surf*EXP(ze(k,iCell)/stokes_decay_depth)
+                 uStokes(k,iCell) = uStokes_surf*EXP(ze(k,iCell)/stokes_depth)
+                 vStokes(k,iCell) = vStokes_surf*EXP(ze(k,iCell)/stokes_depth)
               enddo
 
               do k=1,3

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -223,9 +223,10 @@ module ocn_adc_mixing_fused
 !             [stokes_decay_depth]. This is temporary; eventually MPAS will pass profiles
 !             For now this is calculated using an assumed Langmuir number of La_t and waves in
 !             x/u-direction only
-!             La_t = (surface stokes drift/friction velocity)^(0.5)
-              La_t = 0.0_RKIND
-              uStokes_surf = (La_t**2.0_RKIND)*frictionVelocity
+!             La_t = (friction velocity / surface stokes drift)^(0.5)
+              La_t = 0.3_RKIND
+              stokes_decay_depth = 4.8_RKIND
+              uStokes_surf = 0.0_RKIND !frictionVelocity / (La_t**2.0_RKIND)
               vStokes_surf = 0.0_RKIND
               uStokes(1,iCell) = uStokes_surf
               vStokes(1,iCell) = vStokes_surf

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -168,7 +168,8 @@ module ocn_adc_mixing_fused
 
       real(kind=RKIND) :: Sw, St, Ss, Eav, Dav, sigav, sigavp1, wumdAv, tumdAv, sumdAv, wumdAvp1, tumdAvp1, sumdAvp1
       real(kind=RKIND) :: Swup, KspsUav, KspsDav, KspsUavp1, KspsDavp1, KE, Mcav, lenav,u2av,v2av,w2av
-      real(kind=RKIND) :: w2tTemp, w2tCheck, w2sTemp, w2sCheck, w3temp, w3check2, w3check, mval, KEsps, Uz, Vz, dz
+      real(kind=RKIND) :: w2tTemp, w2tCheck, w2sTemp, w2sCheck, w3temp, w3check2, w3check, mval, KEsps
+      real(kind=RKIND) :: Uz, Vz, Ustz, Vstz, dz
 
       real(kind=RKIND) :: invLen, l, len1, len2, lenmax, integrandTop, integrandBot
       real(kind=RKIND) :: len0, len2_1, len2_2, sfcBuoy, lengthT, bvfT
@@ -211,6 +212,15 @@ module ocn_adc_mixing_fused
               Mc(1,iCell) = 0.0_RKIND
               w2t(1,iCell) = -0.3_RKIND*wstar * wtsfc(iCell)
               w2s(1,iCell) = 0.3_RKIND*wstar * wssfc(iCell)
+
+!             Calculate exponential Stokes drift profiles from surface values & decay depth (delta)
+!             (temporary; eventually MPAS will pass profiles)
+              uStokes(1,iCell) = uStokes_surf
+              vStokes(1,iCell) = vStokes_surf
+              do k=1,nVertLevels
+                 uStokes(k,iCell) = uStokes_surf*EXP(ze(k,iCell)/delta)
+                 vStokes(k,iCell) = vStokes_surf*EXP(ze(k,iCell)/delta)
+              enddo
 
               sfcFrictionVelocitySquared = uwsfc(iCell) + vwsfc(iCell)
               frictionVelocity = sqrt(sfcFrictionVelocitySquared + config_adc_bc_wstar * wstar * wstar)
@@ -454,6 +464,7 @@ module ocn_adc_mixing_fused
 !                   (4) parameterized pressure terms (Rotta, buoyancy)
 !                   (5) buoyancy production and sub-plume scale effects
 !                   (6) splatting (calculated earlier)
+!                   (7) Stokes drift production terms -3*[uw2*d(ustokes)/dz + vw2*d(ustokes)/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
                  w3tend1(k,iCell) = -wumdav**3.0_RKIND*(Eav*(3.0_RKIND*sigav - 2.0_RKIND) &
                    + Dav*(3.0_RKIND*sigav - 1.0_RKIND))
@@ -469,8 +480,10 @@ module ocn_adc_mixing_fused
                  w3tend5(k,iCell) = 3.0_RKIND*grav*(alphaT(k,iCell)*w2t(k,iCell) - betaS(k,iCell)* &
                    w2s(k,iCell)) - 3.0_RKIND*(1.0_RKIND - 2.0_RKIND*sigav)*Mcav*wumdav*Swumd(k,iCell)
 
+                 w3tend7(k,iCell) = - 3.0_RKIND*(uw2(i1,k,iCell)*( uStokes(i1,k,iCell) - uStokes(i1,k+1,iCell)) / dz + vw2(i1,k,iCell)*( vStokes(i1,k,iCell) - vStokes(i1,k+1,iCell)) / dz)
+
                  w3tend(i3_f,k,iCell) = w3tend1(k,iCell) + w3tend2(k,iCell) + w3tend3(k,iCell) + &
-                   w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell)
+                   w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell) + w3tend7(k,iCell)
 
                  if(k>1 .and. k < nVertLevels .and. kappa_w3 > 0.0_RKIND) then
                     w3tend(i3_f,k,iCell) = w3tend(i3_f,k,iCell) + kappa_w3*(w3(i1,k-1,iCell) &
@@ -515,6 +528,8 @@ module ocn_adc_mixing_fused
 
                  Uz = (uvel(k-1,iCell) - uvel(k,iCell)) / dzmid
                  Vz = (vvel(k-1,iCell) - vvel(k,iCell)) / dzmid
+                 Ustz = (uStokes(k-1,iCell) - uStokes(k,iCell)) / dzmid
+                 Vstz = (vStokes(k-1,iCell) - vStokes(k,iCell)) / dzmid
                  Tz = (activeTracers(1,k-1,iCell) - activeTracers(1,k,iCell)) / dzmid
                  Sz = (activeTracers(2,k-1,iCell) - activeTracers(2,k,iCell)) / dzmid
                  
@@ -538,6 +553,7 @@ module ocn_adc_mixing_fused
 !                   (4) production of w2 by buoyancy fluxes (conversion to/from potential energy)
 !                   (5) sub-plume scale effects (based on Lappen & Randall 2001)
 !                   (6) splatting (calculated earlier; converts w2 to u2/v2 near surface)
+!                   (7) Stokes drift production terms -2*[uw*d(ustokes)/dz + vw*d(vstokes)/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
 !      The parameterization consists of a slow (Rotta) term [Rotta, 1951],
 !      a rapid term that depends on gradients in mean velocity [Speziale et al., 1991],
@@ -556,19 +572,23 @@ module ocn_adc_mixing_fused
                  -2.0_RKIND*w2(i1,k,iCell))/3.0_RKIND + (1.0_RKIND/3.0_RKIND*alpha_1 - &
                    alpha_2)*(uw(i1,k,iCell)*Uz + vw(i1,k,iCell)*Vz) - 4.0_RKIND/3.0_RKIND* &
                    C_b*Mc(k,iCell)*(grav*alphaT(k,iCell)*tumd(k,iCell) - &
-                   grav*betaS(k,iCell)*sumd(k,iCell))
+                   grav*betaS(k,iCell)*sumd(k,iCell)) + &
+                   (alpha_st_1 / 3.0_RKIND - alpha_st_2)*(uw(i1,k,iCell)*Usz + vw(i1,k,iCell)*Vsz)
 
                  w2tend4(k,iCell) = 2.0_RKIND*Mc(k,iCell)* &
                    (grav*alphaT(k,iCell)*tumd(k,iCell) - grav*betaS(k,iCell)*sumd(k,iCell))
 
                  w2tend5(k,iCell) = Mc(k,iCell)*(Swumd(k-1,iCell) + Swumd(k,iCell))
+
+                 w2tend7(k,iCell) = -2.0_RKIND*(uw(i1,k,iCell)*Ustz + vw(i1,k,iCell)*Vstz)
 !      Sum the above tendency terms to find the total w2 tendency.
 !      Note this includes a splatting term calculated earlier (w2tend6).
 !      Also, the w2 slow pressure term (within w2tend3) is removed here as it is
 !      included implicitly in the timestepping
                  w2tend(i3_f,k,iCell) = w2tend1(k,iCell) + w2tend2(k,iCell) + &
                    w2tend3(k,iCell) + w2tend4(k,iCell) + w2tend5(k,iCell) + &
-                   w2tend6(k,iCell) + 2.0_RKIND*tauvVel(k,iCell)*w2(i1,k,iCell)/3.0_RKIND
+                   w2tend6(k,iCell) + w2tend7(k,iCell) +  &
+                   2.0_RKIND*tauvVel(k,iCell)*w2(i1,k,iCell)/3.0_RKIND
 
                  if (config_adc_truncate_tend) then
                     w2tend(i3_f,k,iCell) = FLOAT (INT(w2tend(i3_f,k,iCell) * adcRound &
@@ -584,6 +604,7 @@ module ocn_adc_mixing_fused
 !                   (4) gradient and buoyancy production terms of wt [ -w2*dT/dz + t*buoyancy]
 !                   (5) dissipation of wt [ -kappa_FL*[d(wt)/dz]^2 ]
 !                   (6) sub-plume scale effects (based on Lappen & Randall 2001)
+!                   (7) Stokes drift production terms -[ut*d(ustokes)/dz + vt*d(vstokes)/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
                  wttend1(k,iCell) = -1.0_RKIND*(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
                    wumd(k,iCell)*tumd(k,iCell)
@@ -595,7 +616,9 @@ module ocn_adc_mixing_fused
                    (1.0_RKIND - areaFraction(k,iCell))*grav*(alphaT(k,iCell) &
                    *tumd(k,iCell)**2.0_RKIND - betaS(k,iCell)*tumd(k,iCell)*sumd(k,iCell)) + &
                    0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(ut(i1,k,iCell)*Uz + &
-                   vt(i1,k,iCell)*Vz)
+                   vt(i1,k,iCell)*Vz) &
+                   + 0.5_RKIND*(alpha_st_tracer1 - alpha_st_tracer2)* &
+                   (ut(i1,k,iCell)*Ustz + vt(i1,k,iCell)*Vstz)
 
                  wttend4(k,iCell) = - Mc(k,iCell)*wumd(k,iCell)*Tz + &
                    areaFraction(k,iCell)*(1.0_RKIND - areaFraction(k,iCell))*grav*(alphaT(k,iCell) &
@@ -611,12 +634,14 @@ module ocn_adc_mixing_fused
                    -1.0_RKIND/(1.0_RKIND - areaFraction(k,iCell))*((1.0_RKIND - areaFraction(k-1,iCell))* &
                    wt_spsD(k-1,iCell) - (1.0_RKIND - areaFraction(k+1,iCell))*wt_spsD(k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell)))
+
+                 wttend7(k,iCell) = -ut(i1,k,iCell)*Ustz - vt(i1,k,iCell)*Vstz
 !      Sum the above tendency terms to find the total wt tendency.
 !      Also, the wt slow pressure term (within wttend3) is removed here as it is
 !      included implicitly in the timestepping
                  wttend(i3_f,k,iCell) = wttend1(k,iCell) + wttend2(k,iCell) +        &
                    wttend3(k,iCell) + wttend4(k,iCell) + wttend5(k,iCell) + wttend6(k,iCell) + &
-                   tau_tracer(k,iCell)*wt(i1,k,iCell)
+                   wttend7(k,iCell) + tau_tracer(k,iCell)*wt(i1,k,iCell)
 
                  if (config_adc_truncate_tend) then
                     wttend(i3_f,k,iCell) = FLOAT (INT(wttend(i3_f,k,iCell) * adcRound &
@@ -632,6 +657,7 @@ module ocn_adc_mixing_fused
 !                   (4) gradient and buoyancy production terms of ws [ -w2*dS/dz + s*buoyancy]
 !                   (5) dissipation of ws [ -kappa_FL*[d(ws)/dz]^2 ]
 !                   (6) sub-plume scale effects (based on Lappen & Randall 2001)
+!                   (7) Stokes drift production terms -[us*d(ustokes)/dz + vs*d(vstokes)/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
                  wstend1(k,iCell) = -(Entrainment(k,iCell) + Detrainment(k,iCell)) * &
                    wumd(k,iCell)*sumd(k,iCell)
@@ -645,7 +671,9 @@ module ocn_adc_mixing_fused
                    C_b_tracer*grav*areaFraction(k,iCell)* &
                    (1.0_RKIND - areaFraction(k,iCell))*(alphaT(k,iCell) &
                    *tumd(k,iCell)*sumd(k,iCell) - betaS(k,iCell)*sumd(k,iCell)*sumd(k,iCell)) + &
-                   0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + vs(i1,k,iCell)*Vz)
+                   0.5_RKIND*(alpha_tracer1 - alpha_tracer2)*(us(i1,k,iCell)*Uz + vs(i1,k,iCell)*Vz) &
+                   + 0.5_RKIND*(alpha_st_tracer1 - alpha_st_tracer2)* &
+                   (us(i1,k,iCell)*Ustz + vs(i1,k,iCell)*Vstz)
 
                  wstend4(k,iCell) = - Mc(k,iCell)*wumd(k,iCell)*Sz + &
                     grav*areaFraction(k,iCell)* &
@@ -662,12 +690,14 @@ module ocn_adc_mixing_fused
                    -1.0_RKIND/(1.0_RKIND - areaFraction(k,iCell))*((1.0_RKIND - areaFraction(k-1,iCell))* &
                    ws_spsD(k-1,iCell) - (1.0_RKIND - areaFraction(k+1,iCell))*ws_spsD(k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell)))
+
+                 wstend7(k,iCell) = -us(i1,k,iCell)*Ustz - vs(i1,k,iCell)*Vstz
 !      Sum the above tendency terms to find the total ws tendency.
 !      Also, the ws slow pressure term (within wstend3) is removed here as it is
 !      included implicitly in the timestepping
                  wstend(i3_f,k,iCell) = wstend1(k,iCell) + wstend2(k,iCell) + &
                    wstend3(k,iCell) + wstend4(k,iCell) + wstend5(k,iCell) + wstend6(k,iCell) + &
-                   tau_tracer(k,iCell)*ws(i1,k,iCell)
+                   wstend7(k,iCell) + tau_tracer(k,iCell)*ws(i1,k,iCell)
 
                  if (config_adc_truncate_tend) then
                     wstend(i3_f,k,iCell) = FLOAT (INT(wstend(i3_f,k,iCell) * adcRound &
@@ -682,6 +712,7 @@ module ocn_adc_mixing_fused
 !                   (3) shear production of uw [-w2*dU/dz]
 !                   (4) buoyancy production of uw [ u*buoyancy]
 !                   (5) dissipation of uw [ -kappa_FL*[d(uw)/dz]^2 ]
+!                   (6) Stokes production term -[u2*d(ustokes)/dz + uv*d(vstokes)/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
                  uwtend1(k,iCell) = -(uw2(k-1,iCell) - uw2(k,iCell)) / dzmid
 
@@ -690,7 +721,11 @@ module ocn_adc_mixing_fused
                    (alpha_1 - alpha_2)*u2(i1,k,iCell) + (alpha_1 +  &
                    alpha_2)*w2(i1,k,iCell))*Uz + 0.5_RKIND*(alpha_1 - alpha_2)*    &
                    uv(i1,k,iCell)*Vz - C_b*grav*(alphaT(k,iCell)*   &
-                   ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell))
+                   ut(i1,k,iCell) - betaS(k,iCell)*us(i1,k,iCell)) + &
+                   0.5_RKIND*((alpha_st_0 - 4.0_RKIND*alpha_st_1/3.0_RKIND)*KE**2.0_RKIND +  &
+                   (alpha_st_1 - alpha_st_2)*u2(i1,k,iCell) + (alpha_st_1 +  &
+                   alpha_st_2)*w2(i1,k,iCell))*Ustz + 0.5_RKIND*(alpha_st_1 - alpha_st_2)*    &
+                   uv(i1,k,iCell)*Vstz
 
                  uwtend3(k,iCell) = - w2(i1,k,iCell)*Uz
 
@@ -699,9 +734,11 @@ module ocn_adc_mixing_fused
 
                  uwtend5(k,iCell) = kappa_FL*(uw(i1,k-1,iCell) - uw(i1,k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
+
+                 uwtend6(k,iCell) = -u2(i1,k,iCell)*Ustz - uv(i1,k,iCell)*Vstz
 !      Sum the above tendency terms to find the total uw tendency.
                  uwtend(i3_f,k,iCell) = uwtend1(k,iCell) + uwtend2(k,iCell) + &
-                   uwtend3(k,iCell) + uwtend4(k,iCell) + uwtend5(k,iCell)
+                   uwtend3(k,iCell) + uwtend4(k,iCell) + uwtend5(k,iCell) + uwtend6(k,iCell)
 
                  if (config_adc_truncate_tend) then
                     uwtend(i3_f,k,iCell) = FLOAT (INT(uwtend(i3_f,k,iCell) * adcRound &
@@ -716,6 +753,7 @@ module ocn_adc_mixing_fused
 !                   (3) shear production of vw [-w2*dV/dz]
 !                   (4) buoyancy production of vw [ v*buoyancy]
 !                   (5) dissipation of vw [ -kappa_FL*[d(vw)/dz]^2 ]
+!                   (6) Stokes production term -[uv*d(ustokes)/dz + v2*d(vstokes)/dz]
 !      The tendency term is truncated if config_adc_truncate_tend flag it switched on
                  vwtend1(k,iCell) = -(vw2(k-1,iCell) - vw2(k,iCell)) / dzmid
 
@@ -724,7 +762,11 @@ module ocn_adc_mixing_fused
                    (alpha_1 - alpha_2)*v2(i1,k,iCell) + (alpha_1 +  &
                    alpha_2)*w2(i1,k,iCell))*Vz + 0.5_RKIND*(alpha_1 - alpha_2)*    &
                    uv(i1,k,iCell)*Uz - C_b*grav*(alphaT(k,iCell)*   &
-                   vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))
+                   vt(i1,k,iCell) - betaS(k,iCell)*vs(i1,k,iCell))+ &
+                   0.5_RKIND*((alpha_st_0 - 4.0_RKIND*alpha_st_1/3.0_RKIND)*KE**2.0_RKIND +  &
+                   (alpha_st_1 - alpha_st_2)*v2(i1,k,iCell) + (alpha_st_1 +  &
+                   alpha_st_2)*w2(i1,k,iCell))*Vstz + 0.5_RKIND*(alpha_st_1 - alpha_st_2)*    &
+                   uv(i1,k,iCell)*Ustz
 
                  vwtend3(k,iCell) = - w2(i1,k,iCell)*Vz
 
@@ -733,6 +775,8 @@ module ocn_adc_mixing_fused
 
                  vwtend5(k,iCell) = kappa_FL*(vw(i1,k-1,iCell) - vw(i1,k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND
+
+                 vwtend6(k,iCell) = -uv(i1,k,iCell)*Ustz - v2(i1,k,iCell)*Vstz
 !      Sum the above tendency terms to find the total vw tendency.
                  vwtend(i3_f,k,iCell) = vwtend1(k,iCell) + vwtend2(k,iCell) + &
                    vwtend3(k,iCell) + vwtend4(k,iCell) + vwtend5(k,iCell)
@@ -754,6 +798,8 @@ module ocn_adc_mixing_fused
                    - tauVel(k,iCell)*uv(i1,k,iCell)  & ! Rotta
                    + 0.5_RKIND*(alpha_1+alpha_2)* &
                    (uw(i1,k,iCell)*Vz + vw(i1,k,iCell)*Uz) & ! rapid
+                   + 0.5_RKIND*(alpha_st_1 + alpha_st_2)* &
+                   (uw(i1,k,iCell)*Vstz + vw(i1,k,iCell)*Ustz) & ! Stokes
                    - (uw(i1,k,iCell)*Vz + vw(i1,k,iCell)*Uz) & ! shear production
                    + kappa_VAR*(uv(i1,k-1,iCell) - uv(i1,k+1,iCell)) / &
                    (ze(k-1,iCell) - ze(k+1,iCell))**2.0_RKIND ! dissipation
@@ -781,7 +827,9 @@ module ocn_adc_mixing_fused
                    areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND + &
                    (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2) &
                    *uw(i1,k,iCell)*Uz - 2.0_RKIND/3.0_RKIND*alpha_1*vw(i1,k,iCell)*Vz &
-                   + 2.0_RKIND/3.0_RKIND*C_b*B
+                   + 2.0_RKIND/3.0_RKIND*C_b*B + (alpha_st_1/3.0_RKIND + alpha_st_2) &
+                   *uw(i1,k,iCell)*Ustz &
+                   - 2.0_RKIND*alpha_st_1/3.0_RKIND*vw(i1,k,iCell)*Vstz
 
                  u2tend3(k,iCell) = -2.0_RKIND*uw(i1,k,iCell)*Uz
 
@@ -817,7 +865,9 @@ module ocn_adc_mixing_fused
                    areaFraction(k,iCell))*wumd(k,iCell)**2)/3.0_RKIND + &
                    (1.0_RKIND/3.0_RKIND*alpha_1 + alpha_2) &
                    *vw(i1,k,iCell)*Vz - 2.0_RKIND/3.0_RKIND*alpha_1*uw(i1,k,iCell)*Uz &
-                   + 2.0_RKIND/3.0_RKIND*C_b*B
+                   + 2.0_RKIND/3.0_RKIND*C_b*B + (alpha_st_1/3.0_RKIND + alpha_st_2) &
+                   *vw(i1,k,iCell)*Vstz &
+                   - 2.0_RKIND*alpha_st_1/3.0_RKIND*uw(i1,k,iCell)*Ustz
 
                  v2tend3(k,iCell) = -2.0_RKIND*vw(i1,k,iCell)*Vz
 
@@ -847,7 +897,9 @@ module ocn_adc_mixing_fused
                  uttend(i3_f,k,iCell) = -(uwt(k-1,iCell) - uwt(k,iCell))/dz  & ! Transport
                    - ut(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
                    + 0.5_RKIND*(alpha_tracer1 + alpha_tracer2)*wt(i1,k,iCell)*Uz & ! Rapid
-                   - wt(i1,k,iCell)*Uz & ! Rapid
+                   + 0.5_RKIND*(alpha_st_tracer1 + alpha_st_tracer2) &
+                    *wt(i1,k,iCell)*Ustz & ! Stokes
+                   - wt(i1,k,iCell)*Uz & ! Shear production
                    - uw(i1,k,iCell)*Tz ! Gradient production
 
                  if (config_adc_truncate_tend) then
@@ -866,7 +918,9 @@ module ocn_adc_mixing_fused
                  vttend(i3_f,k,iCell) = -(vwt(k-1,iCell) - vwt(k,iCell))/dz  & ! Transport
                    - vt(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
                    + 0.5_RKIND*(alpha_tracer1 + alpha_tracer2)*wt(i1,k,iCell)*Vz & ! Rapid
-                   - wt(i1,k,iCell)*Vz & ! Rapid
+                   + 0.5_RKIND*(alpha_st_tracer1 + alpha_st_tracer2) &
+                    *wt(i1,k,iCell)*Vstz & ! Stokes
+                   - wt(i1,k,iCell)*Vz & ! Shear production
                    - vw(i1,k,iCell)*Tz ! Gradient production
 
                  if (config_adc_truncate_tend) then
@@ -884,6 +938,8 @@ module ocn_adc_mixing_fused
                  ustend(i3_f,k,iCell) = -(uws(k-1,iCell) - uws(k,iCell))/dz  & ! Transport
                    - us(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
                    + 0.5_RKIND*(alpha_tracer1 + alpha_tracer2)*ws(i1,k,iCell)*Uz & ! Rapid
+                   + 0.5_RKIND*(alpha_st_tracer1 + alpha_st_tracer2) &
+                    *ws(i1,k,iCell)*Ustz & ! Stokes
                    - ws(i1,k,iCell)*Uz & ! Shear production
                    - uw(i1,k,iCell)*Sz ! Gradient production
 
@@ -903,7 +959,9 @@ module ocn_adc_mixing_fused
                  vstend(i3_f,k,iCell) = -(vws(k-1,iCell) - vws(k,iCell))/dz  & ! Transport
                    - vs(i1,k,iCell)*tau_tracer(k,iCell) & ! Rotta
                    + 0.5_RKIND*(alpha_tracer1 + alpha_tracer2)*ws(i1,k,iCell)*Vz & ! Rapid
-                   - ws(i1,k,iCell)*Vz & ! Rapid
+                   + 0.5_RKIND*(alpha_st_tracer1 + alpha_st_tracer2) &
+                    *ws(i1,k,iCell)*Vstz & ! Stokes
+                   - ws(i1,k,iCell)*Vz & ! Shear production
                    - vw(i1,k,iCell)*Sz ! Gradient production
 
                  if (config_adc_truncate_tend) then

--- a/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
+++ b/src/core_ocean/shared/mpas_ocn_adcReconstruct.F
@@ -178,9 +178,11 @@ module ocn_adc_mixing_fused
       real(kind=RKIND) :: B, Cval, diff, wtav, dzmid, Ksps, Sz, Tz, w4k, w4kp1, w2k, w2kp1
       real(kind=RKIND) :: lareaFraction, wstar, Q, w3av, tempMoment, frictionVelocity
       real(kind=RKIND) :: sfcFrictionVelocitySquared, wtSumUp, wtSumDn, wsSumUp, wsSumDn
+      real(kind=RKIND) :: uStokes_surf, vStokes_surf, stokes_decay_depth, La_t
 
       real(kind=RKIND),dimension(nVertLevels,nCells) :: Swumd
       real(kind=RKIND),dimension(nVertLevels,nCells) :: tauw3, tau_tracer, tauVel, tauvVel
+      real(kind=RKIND),dimension(nVertLevels,nCells) :: uStokes, vStokes
       real(kind=RKIND),dimension(nVertLevels,nCells) :: areaFractionMid, tumdMid, McMid, wumdMid, sumdMid
 
       real(kind=RKIND) :: SwU, SwD, tau_sfc, d_sqrt_wp2_dz, tp2, sp2, min_wp2_sfc_val, wp2_splat_sfc_correction
@@ -213,18 +215,25 @@ module ocn_adc_mixing_fused
               w2t(1,iCell) = -0.3_RKIND*wstar * wtsfc(iCell)
               w2s(1,iCell) = 0.3_RKIND*wstar * wssfc(iCell)
 
-!             Calculate exponential Stokes drift profiles from surface values & decay depth (delta)
-!             (temporary; eventually MPAS will pass profiles)
-              uStokes(1,iCell) = uStokes_surf
-              vStokes(1,iCell) = vStokes_surf
-              do k=1,nVertLevels
-                 uStokes(k,iCell) = uStokes_surf*EXP(ze(k,iCell)/delta)
-                 vStokes(k,iCell) = vStokes_surf*EXP(ze(k,iCell)/delta)
-              enddo
-
               sfcFrictionVelocitySquared = uwsfc(iCell) + vwsfc(iCell)
               frictionVelocity = sqrt(sfcFrictionVelocitySquared + config_adc_bc_wstar * wstar * wstar)
               frictionVelocity = max( config_adc_frictionVelocityMin, frictionVelocity )
+
+!             Calculate exponential Stokes drift profiles from surface values & decay depth
+!             [stokes_decay_depth]. This is temporary; eventually MPAS will pass profiles
+!             For now this is calculated using an assumed Langmuir number of La_t and waves in
+!             x/u-direction only
+!             La_t = (surface stokes drift/friction velocity)^(0.5)
+              La_t = 0.0_RKIND
+              uStokes_surf = (La_t**2.0_RKIND)*frictionVelocity
+              vStokes_surf = 0.0_RKIND
+              uStokes(1,iCell) = uStokes_surf
+              vStokes(1,iCell) = vStokes_surf
+              do k=1,nVertLevels
+                 uStokes(k,iCell) = uStokes_surf*EXP(ze(k,iCell)/stokes_decay_depth)
+                 vStokes(k,iCell) = vStokes_surf*EXP(ze(k,iCell)/stokes_decay_depth)
+              enddo
+
               do k=1,3
                  u2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
                  v2(k,1,iCell) = config_adc_up2_vp2_factor*config_adc_bc_const*frictionVelocity**2.0_RKIND
@@ -455,6 +464,9 @@ module ocn_adc_mixing_fused
                 SwD = -(1.0_RKIND-2.0_RKIND*areaFraction(k+1,iCell)) &
                    /(areaFraction(k+1,iCell)*(1.0_RKIND-areaFraction(k+1,iCell)))**0.5_RKIND
 
+                Ustz = (uStokes(k,iCell) - uStokes(k+1,iCell)) / dz
+                Vstz = (vStokes(k,iCell) - vStokes(k+1,iCell)) / dz
+
 !      CALCULATE W3 TENDENCY TERMS
 !      Calculate the tendency (rate-of-change) terms for the w3 budget.
 !      The w3 tendency is the sum of the following terms (saved individually)
@@ -480,7 +492,7 @@ module ocn_adc_mixing_fused
                  w3tend5(k,iCell) = 3.0_RKIND*grav*(alphaT(k,iCell)*w2t(k,iCell) - betaS(k,iCell)* &
                    w2s(k,iCell)) - 3.0_RKIND*(1.0_RKIND - 2.0_RKIND*sigav)*Mcav*wumdav*Swumd(k,iCell)
 
-                 w3tend7(k,iCell) = - 3.0_RKIND*(uw2(i1,k,iCell)*( uStokes(i1,k,iCell) - uStokes(i1,k+1,iCell)) / dz + vw2(i1,k,iCell)*( vStokes(i1,k,iCell) - vStokes(i1,k+1,iCell)) / dz)
+                 w3tend7(k,iCell) = - 3.0_RKIND*(uw2(k,iCell)*Ustz + vw2(k,iCell)*Vstz)
 
                  w3tend(i3_f,k,iCell) = w3tend1(k,iCell) + w3tend2(k,iCell) + w3tend3(k,iCell) + &
                    w3tend4(k,iCell) + w3tend5(k,iCell) + w3tend6(k,iCell) + w3tend7(k,iCell)
@@ -573,7 +585,7 @@ module ocn_adc_mixing_fused
                    alpha_2)*(uw(i1,k,iCell)*Uz + vw(i1,k,iCell)*Vz) - 4.0_RKIND/3.0_RKIND* &
                    C_b*Mc(k,iCell)*(grav*alphaT(k,iCell)*tumd(k,iCell) - &
                    grav*betaS(k,iCell)*sumd(k,iCell)) + &
-                   (alpha_st_1 / 3.0_RKIND - alpha_st_2)*(uw(i1,k,iCell)*Usz + vw(i1,k,iCell)*Vsz)
+                   (alpha_st_1 / 3.0_RKIND - alpha_st_2)*(uw(i1,k,iCell)*Ustz + vw(i1,k,iCell)*Vstz)
 
                  w2tend4(k,iCell) = 2.0_RKIND*Mc(k,iCell)* &
                    (grav*alphaT(k,iCell)*tumd(k,iCell) - grav*betaS(k,iCell)*sumd(k,iCell))

--- a/src/core_ocean/shared/mpas_ocn_turbulence.F
+++ b/src/core_ocean/shared/mpas_ocn_turbulence.F
@@ -48,7 +48,8 @@ module ocn_turbulence
                        alpha_st_tracer1, alpha_st_tracer2, alpha_st_0, alpha_st_1, &
                        alpha_st_2, alpha_0, alpha_1, alpha_2, B1, Kt, grav, c_mom, &
                        c_therm, c_mom_w3, c_epsilon, c_slow, c_slow_tracer, slow_w_factor, &
-                       kappa_FL, kappa_w3, kappa_VAR, Cww_D, Cww_E, adcRound
+                       kappa_FL, kappa_w3, kappa_VAR, Cww_D, Cww_E, adcRound, &
+                       La_t, stokes_depth, stokes_angle
 
    integer,public :: iterCount, nCells, nVertLevels
 
@@ -182,6 +183,9 @@ module ocn_turbulence
       kappa_FL = config_adc_kappaFL
       kappa_VAR = config_adc_kappaVAR
       kappa_w3 = config_adc_kappaW3
+      La_t = config_adc_La_t
+      stokes_depth = config_adc_stokes_depth
+      stokes_angle = config_adc_stokes_angle
       adcRound = 10.0_RKIND**config_adc_decimals_to_keep
       iterCount = 1
 
@@ -1243,6 +1247,9 @@ module ocn_turbulence
       kappa_FL = 0.0_RKIND
       kappa_VAR = 0.0_RKIND
       kappa_w3 = 0.0_RKIND
+      La_t = 0.0_RKIND
+      stokes_depth = 0.0_RKIND
+      stokes_angle = 0.0_RKIND
 
       !$acc exit data delete(KspsD,    &
       !$acc                   nCells,   &

--- a/src/core_ocean/shared/mpas_ocn_turbulence.F
+++ b/src/core_ocean/shared/mpas_ocn_turbulence.F
@@ -45,7 +45,8 @@ module ocn_turbulence
 
    real(kind=RKIND),public :: epsilon, &! small value below which w2, v2, u2 cannot go
                        sigmat, Ko, c_b, c_b_tracer, alpha_tracer1, alpha_tracer2, c11, &
-                       alpha_0, alpha_1, alpha_2, B1, Kt, grav, c_mom, &
+                       alpha_st_tracer1, alpha_st_tracer2, alpha_st_0, alpha_st_1, &
+                       alpha_st_2, alpha_0, alpha_1, alpha_2, B1, Kt, grav, c_mom, &
                        c_therm, c_mom_w3, c_epsilon, c_slow, c_slow_tracer, slow_w_factor, &
                        kappa_FL, kappa_w3, kappa_VAR, Cww_D, Cww_E, adcRound
 
@@ -58,16 +59,16 @@ module ocn_turbulence
                        uws, vws, ws2, wt2, areaFraction, Entrainment,        &
                        Detrainment, tumd, sumd, wumd, Mc
 
-   real(kind=RKIND), public, dimension(:,:), allocatable :: w2tend1, w2tend2,     &
-                       w2tend3, w2tend4, w2tend5, w2tend6, wttend1, wttend2,   &
-                       wttend3, wttend4, wttend5, wttend6, w3tend1, w3tend2,   &
-                       w3tend3, w3tend5, w3tend4, w3tend6, wstend1, wstend2,   &
-                       wstend3, wstend4, wstend5, uwtend1, uwtend2,   &
-                       uwtend3, uwtend4, uwtend5, vwtend1, vwtend2,   &
-                       vwtend3, vwtend4, vwtend5, u2tend1, u2tend2,   &
-                       u2tend3, u2tend4, u2tend5, u2tend6, v2tend1, v2tend2,   &
-                       v2tend3, v2tend4, v2tend5, v2tend6, u2cliptend,         &
-                       v2cliptend, w2cliptend, wstend6
+   real(kind=RKIND), public, dimension(:,:), allocatable :: w2tend1, w2tend2, w2tend3, &
+                       w2tend4, w2tend5, w2tend6, w2tend7, wttend1, wttend2,   &
+                       wttend3, wttend4, wttend5, wttend6, wttend7, w3tend1,   &
+                       w3tend2, w3tend3, w3tend4, w3tend5, w3tend6, w3tend7,   &
+                       wstend1, wstend2, wstend3, wstend4, wstend5, wstend6,   &
+                       wstend7, uwtend1, uwtend2, uwtend3, uwtend4, uwtend5,   &
+                       uwtend6, vwtend1, vwtend2, vwtend3, vwtend4, vwtend5,   &
+                       vwtend6, u2tend1, u2tend2, u2tend3, u2tend4, u2tend5,   &
+                       u2tend6, v2tend1, v2tend2, v2tend3, v2tend4, v2tend5,   &
+                       v2tend6, u2cliptend, v2cliptend, w2cliptend
 
    real(kind=RKIND), public, dimension(:,:,:), allocatable :: u2, v2, w2, t2, s2, &
                        uw, vw, wt, ws, w3, uv, ut, vt, us, vs, ts, eps, KspsU, KspsD, &
@@ -113,16 +114,18 @@ module ocn_turbulence
                        uwsTmp, vwsTmp, ws2Tmp, wt2Tmp, areaFractionTmp, EntrainmentTmp,        &
                        DetrainmentTmp, tumdTmp, sumdTmp, wumdTmp, McTmp, lendnTmp, lenupTmp
 
-   real(kind=RKIND), dimension(:,:), pointer :: w2tend1Tmp, w2tend2Tmp,     &
-                       w2tend3Tmp, w2tend4Tmp, w2tend5Tmp, w2tend6Tmp, wttend1Tmp, wttend2Tmp,   &
-                       wttend3Tmp, wttend4Tmp, wttend5Tmp, wttend6Tmp, w3tend1Tmp, w3tend2Tmp,   &
-                       w3tend3Tmp, w3tend5Tmp, w3tend4Tmp, w3tend6Tmp, wstend1Tmp, wstend2Tmp,   &
-                       wstend3Tmp, wstend4Tmp, wstend5Tmp, uwtend1Tmp, uwtend2Tmp,   &
-                       uwtend3Tmp, uwtend4Tmp, uwtend5Tmp, vwtend1Tmp, vwtend2Tmp,   &
-                       vwtend3Tmp, vwtend4Tmp, vwtend5Tmp, u2tend1Tmp, u2tend2Tmp,   &
-                       u2tend3Tmp, u2tend4Tmp, u2tend5Tmp, u2tend6Tmp, v2tend1Tmp, v2tend2Tmp,   &
-                       v2tend3Tmp, v2tend4Tmp, v2tend5Tmp, v2tend6Tmp, u2cliptendTmp,         &
-                       v2cliptendTmp, w2cliptendTmp, wstend6Tmp
+   real(kind=RKIND), dimension(:,:), pointer :: w2tend1Tmp, w2tend2Tmp, w2tend3Tmp,  &
+                       w2tend4Tmp, w2tend5Tmp, w2tend6Tmp, w2tend7Tmp, wttend1Tmp,   &
+                       wttend2Tmp, wttend3Tmp, wttend4Tmp, wttend5Tmp, wttend6Tmp,   &
+                       wttend7Tmp, w3tend1Tmp, w3tend2Tmp, w3tend3Tmp,               &
+                       w3tend4Tmp, w3tend5Tmp, w3tend6Tmp, w3tend7Tmp, wstend1Tmp,   &
+                       wstend2Tmp, wstend3Tmp, wstend4Tmp, wstend5Tmp, wstend6Tmp,   &
+                       wstend7Tmp, uwtend1Tmp, uwtend2Tmp, uwtend3Tmp, uwtend4Tmp,   &
+                       uwtend5Tmp, uwtend6Tmp, vwtend1Tmp, vwtend2Tmp, vwtend3Tmp,   &
+                       vwtend4Tmp, vwtend5Tmp, vwtend6Tmp, u2tend1Tmp, u2tend2Tmp,   &
+                       u2tend3Tmp, u2tend4Tmp, u2tend5Tmp, u2tend6Tmp, v2tend1Tmp,   &
+                       v2tend2Tmp, v2tend3Tmp, v2tend4Tmp, v2tend5Tmp, v2tend6Tmp,   &
+                       u2cliptendTmp, v2cliptendTmp, w2cliptendTmp
 
    real(kind=RKIND), dimension(:,:), pointer :: u2Tmp, v2Tmp, w2Tmp, t2Tmp, s2Tmp, &
                        uwTmp, vwTmp, wtTmp, wsTmp, w3Tmp, uvTmp, utTmp, vtTmp, usTmp,&
@@ -158,6 +161,11 @@ module ocn_turbulence
       alpha_2 = config_adc_alpha_2
       alpha_tracer1 = config_adc_alpha_tracer1
       alpha_tracer2 = config_adc_alpha_tracer2
+      alpha_st_0 = config_adc_alpha_st_0
+      alpha_st_1 = config_adc_alpha_st_1
+      alpha_st_2 = config_adc_alpha_st_2
+      alpha_st_tracer1 = config_adc_alpha_st_tracer1
+      alpha_st_tracer2 = config_adc_alpha_st_tracer2
       B1 = 16.6_RKIND
       Kt = 0.4_RKIND
       c_b = config_adc_c_b
@@ -279,34 +287,40 @@ module ocn_turbulence
       call mpas_pool_get_array(adcTendPool, 'w2tend4', w2tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend5', w2tend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend6', w2tend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'w2tend7', w2tend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend1', w3tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend2', w3tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend3', w3tend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend4', w3tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend5', w3tend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend6', w3tend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'w3tend7', w3tend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend1', wttend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend2', wttend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend3', wttend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend4', wttend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend5', wttend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend6', wttend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'wttend7', wttend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend1', wstend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend2', wstend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend3', wstend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend4', wstend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend5', wstend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend6', wstend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'wstend7', wstend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend1', uwtend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend2', uwtend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend3', uwtend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend4', uwtend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend5', uwtend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'uwtend6', uwtend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend1', vwtend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend2', vwtend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend3', vwtend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend4', vwtend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend5', vwtend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'vwtend6', vwtend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend1', u2tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend2', u2tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend3', u2tend3Tmp)
@@ -329,28 +343,33 @@ module ocn_turbulence
       allocate( w2tend4( nVertLevelsP1, nCells ))
       allocate( w2tend5( nVertLevelsP1, nCells ))
       allocate( w2tend6( nVertLevelsP1, nCells ))
+      allocate( w2tend7( nVertLevelsP1, nCells ))
       allocate( wttend1( nVertLevelsP1, nCells ))
       allocate( wttend2( nVertLevelsP1, nCells ))
       allocate( wttend3( nVertLevelsP1, nCells ))
       allocate( wttend4( nVertLevelsP1, nCells ))
       allocate( wttend5( nVertLevelsP1, nCells ))
       allocate( wttend6( nVertLevelsP1, nCells ))
+      allocate( wttend7( nVertLevelsP1, nCells ))
       allocate( wstend1( nVertLevelsP1, nCells ))
       allocate( wstend2( nVertLevelsP1, nCells ))
       allocate( wstend3( nVertLevelsP1, nCells ))
       allocate( wstend4( nVertLevelsP1, nCells ))
       allocate( wstend5( nVertLevelsP1, nCells ))
       allocate( wstend6( nVertLevelsP1, nCells ))
+      allocate( wstend7( nVertLevelsP1, nCells ))
       allocate( uwtend1( nVertLevelsP1, nCells ))
       allocate( uwtend2( nVertLevelsP1, nCells ))
       allocate( uwtend3( nVertLevelsP1, nCells ))
       allocate( uwtend4( nVertLevelsP1, nCells ))
       allocate( uwtend5( nVertLevelsP1, nCells ))
+      allocate( uwtend6( nVertLevelsP1, nCells ))
       allocate( vwtend1( nVertLevelsP1, nCells ))
       allocate( vwtend2( nVertLevelsP1, nCells ))
       allocate( vwtend3( nVertLevelsP1, nCells ))
       allocate( vwtend4( nVertLevelsP1, nCells ))
       allocate( vwtend5( nVertLevelsP1, nCells ))
+      allocate( vwtend6( nVertLevelsP1, nCells ))
       allocate( v2tend1( nVertLevelsP1, nCells ))
       allocate( v2tend2( nVertLevelsP1, nCells ))
       allocate( v2tend3( nVertLevelsP1, nCells ))
@@ -369,6 +388,7 @@ module ocn_turbulence
       allocate( w3tend4( nVertLevels, nCells ))
       allocate( w3tend5( nVertLevels, nCells ))
       allocate( w3tend6( nVertLevels, nCells ))
+      allocate( w3tend7( nVertLevels, nCells ))
       allocate( u2cliptend( nVertLevelsP1, nCells ))
       allocate( v2cliptend( nVertLevelsP1, nCells ))
       allocate( w2cliptend( nVertLevelsP1, nCells ))
@@ -379,34 +399,40 @@ module ocn_turbulence
       w2tend4 = w2tend4Tmp
       w2tend5 = w2tend5Tmp
       w2tend6 = w2tend6Tmp
+      w2tend7 = w2tend7Tmp
       w3tend1 = w3tend1Tmp
       w3tend2 = w3tend2Tmp
       w3tend3 = w3tend3Tmp
       w3tend4 = w3tend4Tmp
       w3tend5 = w3tend5Tmp
       w3tend6 = w3tend6Tmp
+      w3tend7 = w3tend7Tmp
       wttend1 = wttend1Tmp
       wttend2 = wttend2Tmp
       wttend3 = wttend3Tmp
       wttend4 = wttend4Tmp
       wttend5 = wttend5Tmp
       wttend6 = wttend6Tmp
+      wttend7 = wttend7Tmp
       wstend1 = wstend1Tmp
       wstend2 = wstend2Tmp
       wstend3 = wstend3Tmp
       wstend4 = wstend4Tmp
       wstend5 = wstend5Tmp
       wstend6 = wstend6Tmp
+      wstend7 = wstend7Tmp
       uwtend1 = uwtend1Tmp
       uwtend2 = uwtend2Tmp
       uwtend3 = uwtend3Tmp
       uwtend4 = uwtend4Tmp
       uwtend5 = uwtend5Tmp
+      uwtend6 = uwtend6Tmp
       vwtend1 = vwtend1Tmp
       vwtend2 = vwtend2Tmp
       vwtend3 = vwtend3Tmp
       vwtend4 = vwtend4Tmp
       vwtend5 = vwtend5Tmp
+      vwtend6 = vwtend6Tmp
       u2tend1 = u2tend1Tmp
       u2tend2 = u2tend2Tmp
       u2tend3 = u2tend3Tmp
@@ -717,16 +743,18 @@ module ocn_turbulence
                        uwsTmp, vwsTmp, ws2Tmp, wt2Tmp, areaFractionTmp, EntrainmentTmp,        &
                        DetrainmentTmp, tumdTmp, sumdTmp, wumdTmp, McTmp, lendnTmp, lenupTmp
 
-   real(kind=RKIND), dimension(:,:), pointer :: w2tend1Tmp, w2tend2Tmp,     &
-                       w2tend3Tmp, w2tend4Tmp, w2tend5Tmp, w2tend6Tmp, wttend1Tmp, wttend2Tmp,   &
-                       wttend3Tmp, wttend4Tmp, wttend5Tmp, wttend6Tmp, w3tend1Tmp, w3tend2Tmp,   &
-                       w3tend3Tmp, w3tend5Tmp, w3tend4Tmp, w3tend6Tmp, wstend1Tmp, wstend2Tmp,   &
-                       wstend3Tmp, wstend4Tmp, wstend5Tmp, uwtend1Tmp, uwtend2Tmp,   &
-                       uwtend3Tmp, uwtend4Tmp, uwtend5Tmp, vwtend1Tmp, vwtend2Tmp,   &
-                       vwtend3Tmp, vwtend4Tmp, vwtend5Tmp, u2tend1Tmp, u2tend2Tmp,   &
-                       u2tend3Tmp, u2tend4Tmp, u2tend5Tmp, u2tend6Tmp, v2tend1Tmp, v2tend2Tmp,   &
-                       v2tend3Tmp, v2tend4Tmp, v2tend5Tmp, v2tend6Tmp, u2cliptendTmp,         &
-                       v2cliptendTmp, w2cliptendTmp, wstend6Tmp
+   real(kind=RKIND), dimension(:,:), pointer :: w2tend1Tmp, w2tend2Tmp, w2tend3Tmp,  &
+                       w2tend4Tmp, w2tend5Tmp, w2tend6Tmp, w2tend7Tmp, wttend1Tmp,   &
+                       wttend2Tmp, wttend3Tmp, wttend4Tmp, wttend5Tmp, wttend6Tmp,   &
+                       wttend7Tmp, w3tend1Tmp, w3tend2Tmp, w3tend3Tmp,               &
+                       w3tend4Tmp, w3tend5Tmp, w3tend6Tmp, w3tend7Tmp, wstend1Tmp,   &
+                       wstend2Tmp, wstend3Tmp, wstend4Tmp, wstend5Tmp, wstend6Tmp,   &
+                       wstend7Tmp, uwtend1Tmp, uwtend2Tmp, uwtend3Tmp, uwtend4Tmp,   &
+                       uwtend5Tmp, uwtend6Tmp, vwtend1Tmp, vwtend2Tmp, vwtend3Tmp,   &
+                       vwtend4Tmp, vwtend5Tmp, vwtend6Tmp, u2tend1Tmp, u2tend2Tmp,   &
+                       u2tend3Tmp, u2tend4Tmp, u2tend5Tmp, u2tend6Tmp, v2tend1Tmp,   &
+                       v2tend2Tmp, v2tend3Tmp, v2tend4Tmp, v2tend5Tmp, v2tend6Tmp,   &
+                       u2cliptendTmp, v2cliptendTmp, w2cliptendTmp
 
    real(kind=RKIND), dimension(:,:), pointer :: u2Tmp, v2Tmp, w2Tmp, t2Tmp, s2Tmp, &
                        uwTmp, vwTmp, wtTmp, wsTmp, w3Tmp, uvTmp, utTmp, vtTmp, usTmp,&
@@ -991,34 +1019,40 @@ module ocn_turbulence
       call mpas_pool_get_array(adcTendPool, 'w2tend4', w2tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend5', w2tend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'w2tend6', w2tend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'w2tend7', w2tend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend1', w3tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend2', w3tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend3', w3tend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend4', w3tend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend5', w3tend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'w3tend6', w3tend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'w3tend7', w3tend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend1', wttend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend2', wttend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend3', wttend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend4', wttend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend5', wttend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'wttend6', wttend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'wttend7', wttend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend1', wstend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend2', wstend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend3', wstend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend4', wstend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend5', wstend5Tmp)
       call mpas_pool_get_array(adcTendPool, 'wstend6', wstend6Tmp)
+      call mpas_pool_get_array(adcTendPool, 'wstend7', wstend7Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend1', uwtend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend2', uwtend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend3', uwtend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend4', uwtend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'uwtend5', uwtend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'uwtend6', uwtend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend1', vwtend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend2', vwtend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend3', vwtend3Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend4', vwtend4Tmp)
       call mpas_pool_get_array(adcTendPool, 'vwtend5', vwtend5Tmp)
+      call mpas_pool_get_array(adcTendPool, 'vwtend6', vwtend6Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend1', u2tend1Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend2', u2tend2Tmp)
       call mpas_pool_get_array(adcTendPool, 'u2tend3', u2tend3Tmp)
@@ -1041,34 +1075,40 @@ module ocn_turbulence
       w2tend4Tmp = w2tend4
       w2tend5Tmp = w2tend5
       w2tend6Tmp = w2tend6
+      w2tend7Tmp = w2tend7
       w3tend1Tmp = w3tend1
       w3tend2Tmp = w3tend2
       w3tend3Tmp = w3tend3
       w3tend4Tmp = w3tend4
       w3tend5Tmp = w3tend5
       w3tend6Tmp = w3tend6
+      w3tend7Tmp = w3tend7
       wttend1Tmp = wttend1
       wttend2Tmp = wttend2
       wttend3Tmp = wttend3
       wttend4Tmp = wttend4
       wttend5Tmp = wttend5
       wttend6Tmp = wttend6
+      wttend7Tmp = wttend7
       wstend1Tmp = wstend1
       wstend2Tmp = wstend2
       wstend3Tmp = wstend3
       wstend4Tmp = wstend4
       wstend5Tmp = wstend5
       wstend6Tmp = wstend6
+      wstend7Tmp = wstend7
       uwtend1Tmp = uwtend1
       uwtend2Tmp = uwtend2
       uwtend3Tmp = uwtend3
       uwtend4Tmp = uwtend4
       uwtend5Tmp = uwtend5
+      uwtend6Tmp = uwtend6
       vwtend1Tmp = vwtend1
       vwtend2Tmp = vwtend2
       vwtend3Tmp = vwtend3
       vwtend4Tmp = vwtend4
       vwtend5Tmp = vwtend5
+      vwtend6Tmp = vwtend6
       u2tend1Tmp = u2tend1
       u2tend2Tmp = u2tend2
       u2tend3Tmp = u2tend3
@@ -1184,6 +1224,11 @@ module ocn_turbulence
       alpha_2 = 0.0_RKIND
       alpha_tracer1 = 0.0_RKIND
       alpha_tracer2 = 0.0_RKIND
+      alpha_st_0 = 0.0_RKIND
+      alpha_st_1 = 0.0_RKIND
+      alpha_st_2 = 0.0_RKIND
+      alpha_st_tracer1 = 0.0_RKIND
+      alpha_st_tracer2 = 0.0_RKIND
       B1 = 0.0_RKIND
       Kt = 0.0_RKIND
       c_mom = 0.0_RKIND
@@ -1397,34 +1442,40 @@ module ocn_turbulence
                  w2tend4,     &
                  w2tend5,     &
                  w2tend6,     &
+                 w2tend7,     &
                  w3tend1,     &
                  w3tend2,     &
                  w3tend3,     &
                  w3tend4,     &
                  w3tend5,     &
                  w3tend6,     &
+                 w3tend7,     &
                  wttend1,     &
                  wttend2,     &
                  wttend3,     &
                  wttend4,     &
                  wttend5,     &
                  wttend6,     &
+                 wttend7,     &
                  wstend1,     &
                  wstend2,     &
                  wstend3,     &
                  wstend4,     &
                  wstend5,     &
                  wstend6,     &
+                 wstend7,     &
                  uwtend1,     &
                  uwtend2,     &
                  uwtend3,     &
                  uwtend4,     &
                  uwtend5,     &
+                 uwtend6,     &
                  vwtend1,     &
                  vwtend2,     &
                  vwtend3,     &
                  vwtend4,     &
                  vwtend5,     &
+                 vwtend6,     &
                  u2tend1,     &
                  u2tend2,     &
                  u2tend3,     &

--- a/src/core_ocean/shared/mpas_ocn_vmix_adc.F
+++ b/src/core_ocean/shared/mpas_ocn_vmix_adc.F
@@ -528,19 +528,20 @@ contains
                 ws2, wt2, areaFraction, Entrainment, &
                 Detrainment, tumd, sumd, wumd,       &
                 w2tend1, w2tend2, w2tend3, w2tend4,  &
-                w2tend5, w2tend6, w3tend1, w3tend2,  &
-                w3tend3, w3tend4, w3tend5, w3tend6,  &
-                wttend1, wttend2, wttend3, wttend6,  &
-                wttend4, wttend5, wstend1, wstend2,  &
-                wstend3, wstend4, wstend5, wstend6,  &
+                w2tend5, w2tend6, w2tend7, w3tend1,  &
+                w3tend2, w3tend3, w3tend4, w3tend5,  &
+                w3tend6, w3tend7, wttend1, wttend2,  &
+                wttend3, wttend4, wttend5, wttend6,  &
+                wttend7, wstend1, wstend2, wstend3,  &
+                wstend4, wstend5, wstend6, wstend7,  &
                 uwtend1, uwtend2, uwtend3, uwtend4,  &
-                uwtend5, vwtend1, vwtend2, vwtend3,  &
-                vwtend4, vwtend5, u2tend1, u2tend2,  &
-                u2tend3, u2tend4, u2tend5, u2tend6,  &
-                v2tend1, v2tend2, v2tend3, v2tend4,  &
-                v2tend5, v2tend6, u2cliptend,        &
-                v2cliptend, w2cliptend, u2tend,      &
-                v2tend, w2tend, wttend, wstend,      &
+                uwtend5, uwtend6, vwtend1, vwtend2,  &
+                vwtend3, vwtend4, vwtend5, vwtend6,  &
+                u2tend1, u2tend2, u2tend3, u2tend4,  &
+                u2tend5, u2tend6, v2tend1, v2tend2,  &
+                v2tend3, v2tend4,v2tend5, v2tend6,   &
+                u2cliptend, v2cliptend, w2cliptend,  &
+                u2tend,v2tend, w2tend, wttend, wstend, &
                 uwtend, vwtend, w3tend, uvtend,      &
                 epstend, uttend, vttend, ustend,     &
                 vstend, tstend, u2, v2, w2, wt, ws,  &


### PR DESCRIPTION
This PR adds Stokes drift terms to the ADC closure. This allows the closure scheme to emulate Langmuir (surface-wave-driven) turbulence in addition to its current capability to simulate convective and shear-driven turbulence. A summary of additions/changes and a full description of the added terms is given below.

# Highlights of PR

- There are four new parameters that control the wave properties:
**config_adc_langmuir**:  if .True. then waves are included in scheme, otherwise the Stokes drift is zero (default: .False.)
**config_adc_La_t**: Turbulent Langmuir number $La_t = \sqrt{\frac{u_*}{|u_{s0}|}} $, default value is 0.3 equivalent to equilibrium wind-sea (but requires config_adc_langmuir=.True. to take effect)
**config_adc_stokes_depth**: exponential decay depth of Stokes drift profile (default = 4.8m, assumed monochromatic wave)
**config_adc_stokes_angle**: Sets angle between surface wind stress and Stokes drift. Default is 0 (aligned wind and waves), units are _radians_.

- Explicit Stokes terms are included in all budgets for turbulent statistics involving vertical velocity (such as w2, w3, wt, uw, etc.). These terms are derived from the Craik-Leibovich equations (see for example Harcourt 2013).

- New closure terms for pressure-strain and pressure-scalar gradient correlations which involve the Stokes drift. The pressure-strain closure is based on Pearson et al. (2019). The pressure-scalar closure is untested but is assumed to be on analogy with the current shear closure currently used (if you're interested I have some ramblings here).

- New closure constants added for Stokes terms (`alpha_st_X` and `alpha_st_tracerX` etc.)

- Also fixed some minor unit errors in the ADC registry list for w3tend terms

## Tests of PR

I have tested the code with `config_adc_langmuir`=.false. and it reproduces old code bit for bit. Switching the waves on increases TKE and makes skewness more negative. Further testing/tuning of Langmuir ADC against LES will be done in the future.

# Summary of Stokes drift effects in ADC equations

The equations governing the turbulence statistics of a flow can be found by Reynolds averaging to find equations for turbulent statistics. The inclusion of a Stokes drift, both explicitly and in pressure-related closure assumptions, leads to the following additional terms in the budgets for turbulent fluxes and variances (note that $D/Dt$ includes the advection by both Eulerian flow _and_ Stokes drift and **bold terms** denote the explicit (non-closure) Stokes terms),

## Variances & Skewness

$\frac{D_L \overline{w'w'}}{D t} =\ldots - \left(\mathbf{2} - \frac{\alpha^{st}_1}{3}+\alpha_2^{st} \right)\left[\overline{u'w'}\frac{\partial u^{st}}{\partial z} + \overline{v'w'}\frac{\partial v^{st}}{\partial z}\right],$

$\frac{D_L \overline{u'u'}}{D t}  =\ldots + \left(\frac{\alpha_1^{st}}{3} + \alpha_2^{st}\right)\overline{u'w'}\frac{\partial u^{st}}{\partial z} -  \frac{2\alpha_1^{st}}{3}\overline{v'w'}\frac{\partial v^{st}}{\partial z}$

$\frac{D_L \overline{v'v'}}{D t} =\ldots + \left(\frac{\alpha_1^{st}}{3} + \alpha_2^{st}\right)\overline{v'w'}\frac{\partial v^{st}}{\partial z} -  \frac{2\alpha_1^{st}}{3}\overline{u'w'}\frac{\partial u^{st}}{\partial z}$

$\frac{D_L \overline{\phi'\phi'}}{D t} =\ldots \textrm{No wave or pressure effects}$

$\frac{D_L \overline{w'w'w'}}{D t} =\ldots - 3\overline{u'w'w'}\frac{\partial u^{st}}{\partial z} - 3\overline{v'w'w'}\frac{\partial v^{st}}{\partial z}, \qquad \textrm{ignoring Stokes effects in $- 3\overline{w'w'\frac{\partial p'}{\partial z}}$}$

## Momentum Fluxes

$\frac{D_L \overline{u'w'}}{D t} =\ldots - \left(\mathbf{1} - \frac{\alpha_1^{st} - \alpha_2^{st}}{2}\right)\left[\overline{u'u'}\frac{\partial u^{st}}{\partial z} + \overline{u'v'}\frac{\partial v^{st}}{\partial z}\right] +\left(\frac{\alpha_0^{st}}{2} - \frac{2\alpha_1^{st}}{3}\right)e\frac{\partial u^{st}}{\partial z} + \left(\frac{\alpha_1^{st} + \alpha_2^{st}}{2}\right)\overline{w'w'}\frac{\partial u^{st}}{\partial z}$

$\frac{D_L \overline{v'w'}}{D t} =\ldots - \left(\mathbf{1} - \frac{\alpha_1^{st} - \alpha_2^{st}}{2}\right)\left[\overline{u'v'}\frac{\partial u^{st}}{\partial z} + \overline{v'v'}\frac{\partial v^{st}}{\partial z}\right] + \left(\frac{\alpha_0^{st}}{2} - \frac{2\alpha_1^{st}}{3}\right)e\frac{\partial v^{st}}{\partial z} + \left(\frac{\alpha_1^{st} + \alpha_2^{st}}{2}\right)\overline{w'w'}\frac{\partial v^{st}}{\partial z}$

$\frac{D_L \overline{u'v'}}{D t} =\ldots + \frac{\alpha_1^{st}+\alpha_2^{st}}{2} \left(\overline{v'w'}\frac{\partial u^{st}}{\partial z} + \overline{u'w'}\frac{\partial v^{st}}{\partial z} \right)$

## Tracer fluxes

$ \frac{D_L \overline{w'\phi'}}{D t} =\ldots - \left[\mathbf{1}-\left(\frac{\alpha_{\phi 1}^{st} - \alpha_{\phi 2}^{st}}{2}\right)\right]\left[\overline{u'\phi'}\frac{\partial u^{st}}{\partial z} + \overline{v'\phi'}\frac{\partial v^{st}}{\partial z}\right]$

$\frac{D_L \overline{u'\phi'}}{D t} =\ldots + \left(\frac{\alpha_{\phi 1}^{st} + \alpha_{\phi 2}^{st}}{2}\right)\overline{w'\phi'}\frac{\partial\overline{u^{st}}}{\partial z}$

$\frac{D_L \overline{v'\phi'}}{D t} =\ldots + \left(\frac{\alpha_{\phi 1}^{st} + \alpha_{\phi 2}^{st}}{2}\right)\overline{w'\phi'}\frac{\partial\overline{v^{st}}}{\partial z}$


